### PR TITLE
fix: support for 12 hour time Locale setting (hourCycle)

### DIFF
--- a/Sources/iCalendarParser/Models/DateTimeType.swift
+++ b/Sources/iCalendarParser/Models/DateTimeType.swift
@@ -1,5 +1,24 @@
 import Foundation
 
+
+extension Locale {
+    static func is12HoursFormat() -> Bool {
+        DateFormatter.dateFormat(fromTemplate: "j", options: 0, locale: Locale.current)?.range(of: "a") != nil
+    }
+
+    static func is24HoursFormat() -> Bool {
+        !Self.is12HoursFormat()
+    }
+
+    func is12HoursFormat() -> Bool {
+        DateFormatter.dateFormat(fromTemplate: "j", options: 0, locale: self)?.range(of: "a") != nil
+    }
+
+    func is24HoursFormat() -> Bool {
+        !is12HoursFormat()
+    }
+}
+
 public enum DateTimeType {
     case date
     case dateTime
@@ -17,7 +36,8 @@ public enum DateTimeType {
         } else {
             formatter.timeZone = TimeZone(abbreviation: "UTC")
         }
-
+        
+        
         formatter.dateFormat = {
             switch self {
             case .date:
@@ -28,7 +48,15 @@ public enum DateTimeType {
                     : "yyyyMMdd'T'HHmmss"
             }
         }()
-
+        
+        formatter.locale = {
+            if Locale.is12HoursFormat() {
+                return Locale(identifier: "en_US_POSIX")
+            } else {
+                return Locale.current
+            }
+        }()
+        
         return formatter
     }
 }

--- a/Tests/iCalendarParserTests/DateTimeTypeTests.swift
+++ b/Tests/iCalendarParserTests/DateTimeTypeTests.swift
@@ -26,4 +26,18 @@ final class DateTimeTypeTests: XCTestCase {
         let wrongDate = dateTime.type.dateFormatter().date(from: "19700327T020000")
         XCTAssertNotEqual(dateTime.date, wrongDate)
     }
+    
+    func testCorrectHourCycle() {
+        // to test this toggle off/on 24-hour time in settings
+        let property = ICProperty("DTSTART", "19700329T020000")
+        let dateTime = PropertyBuilder.buildDateTime(from: property)!
+        let dateFormatter = dateTime.type.dateFormatter()
+        let currentLocale = Locale.current
+        if (currentLocale.is12HoursFormat()){
+            XCTAssert(dateFormatter.locale.hourCycle == .oneToTwelve)
+        }
+        else {
+            XCTAssert(dateFormatter.locale.hourCycle == .zeroToTwentyThree)
+        }
+    }
 }


### PR DESCRIPTION
fixes #5 
When 24-hour time (Locale.current.hourCycle is equal to .zeroToTwentyThree) is toggled ON in Settings, everything works as expected.
When 24-hour time is toggled OFF in Settings (Locale.current.hourCycle is equal to .oneToTwelve), certain Date fields (like dstart, dtend) were nil. To fix that issue, the 'formatter' in DateTimeType needs to be set up as "en_US_POSIX" if 24-hour time is OFF.