### PR TITLE
fix: use stable locale for date parsing

### DIFF
--- a/Sources/iCalendarParser/Models/DateTimeType.swift
+++ b/Sources/iCalendarParser/Models/DateTimeType.swift
@@ -1,24 +1,5 @@
 import Foundation
 
-
-extension Locale {
-    static func is12HoursFormat() -> Bool {
-        DateFormatter.dateFormat(fromTemplate: "j", options: 0, locale: Locale.current)?.range(of: "a") != nil
-    }
-
-    static func is24HoursFormat() -> Bool {
-        !Self.is12HoursFormat()
-    }
-
-    func is12HoursFormat() -> Bool {
-        DateFormatter.dateFormat(fromTemplate: "j", options: 0, locale: self)?.range(of: "a") != nil
-    }
-
-    func is24HoursFormat() -> Bool {
-        !is12HoursFormat()
-    }
-}
-
 public enum DateTimeType {
     case date
     case dateTime
@@ -28,6 +9,7 @@ public enum DateTimeType {
         tzId: String? = nil
     ) -> DateFormatter {
         let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
 
         if let tzId {
             formatter.timeZone = TimeZone(identifier: tzId)
@@ -36,8 +18,7 @@ public enum DateTimeType {
         } else {
             formatter.timeZone = TimeZone(abbreviation: "UTC")
         }
-        
-        
+
         formatter.dateFormat = {
             switch self {
             case .date:
@@ -48,15 +29,7 @@ public enum DateTimeType {
                     : "yyyyMMdd'T'HHmmss"
             }
         }()
-        
-        formatter.locale = {
-            if Locale.is12HoursFormat() {
-                return Locale(identifier: "en_US_POSIX")
-            } else {
-                return Locale.current
-            }
-        }()
-        
+
         return formatter
     }
 }

--- a/Tests/iCalendarParserTests/DateTimeTypeTests.swift
+++ b/Tests/iCalendarParserTests/DateTimeTypeTests.swift
@@ -27,17 +27,20 @@ final class DateTimeTypeTests: XCTestCase {
         XCTAssertNotEqual(dateTime.date, wrongDate)
     }
     
-    func testCorrectHourCycle() {
-        // to test this toggle off/on 24-hour time in settings
-        let property = ICProperty("DTSTART", "19700329T020000")
-        let dateTime = PropertyBuilder.buildDateTime(from: property)!
-        let dateFormatter = dateTime.type.dateFormatter()
-        let currentLocale = Locale.current
-        if (currentLocale.is12HoursFormat()){
-            XCTAssert(dateFormatter.locale.hourCycle == .oneToTwelve)
-        }
-        else {
-            XCTAssert(dateFormatter.locale.hourCycle == .zeroToTwentyThree)
-        }
+    func testDateFormatterUsesFixedLocale() throws {
+        let formatter = DateTimeType.dateTime.dateFormatter(tzId: "UTC")
+
+        XCTAssertEqual(formatter.locale.identifier, "en_US_POSIX")
+
+        let date = try XCTUnwrap(formatter.date(from: "19700329T020000"))
+        let components = Calendar(identifier: .gregorian).dateComponents(
+            in: try XCTUnwrap(TimeZone(identifier: "UTC")),
+            from: date
+        )
+
+        XCTAssertEqual(components.year, 1970)
+        XCTAssertEqual(components.month, 3)
+        XCTAssertEqual(components.day, 29)
+        XCTAssertEqual(components.hour, 2)
     }
 }


### PR DESCRIPTION
Addresses the uncleared point in https://github.com/redryerye/iCalendarParser/pull/6