### PR TITLE
docs: update ci badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p>
     <a href="https://github.com/redryerye/iCalendarParser/actions">
-      <img src="https://github.com/redryerye/iCalendarParser/workflows/ci/badge.svg?branch=main">
+      <img src="https://github.com/redryerye/iCalendarParser/actions/workflows/ci.yml/badge.svg?branch=main">
     </a>
     <img src="https://img.shields.io/badge/Swift-5.7-ff69b4.svg" />
     <img src="https://img.shields.io/badge/license-MIT-black.svg" />


### PR DESCRIPTION
## Summary

- Updates the README CI badge to use GitHub's workflow-file badge endpoint.
- Replaces the older `/workflows/ci/badge.svg` URL that was rendering `no status`.

## Validation

- Verified the old badge endpoint returned `ci - no status`.
- Verified `actions/workflows/ci.yml/badge.svg?branch=main` returned `ci - passing`.

## Impact

The README now displays the current GitHub Actions status for the `ci.yml` workflow on `main`.