### PR TITLE
feat: expose event text list properties

### DIFF
--- a/Sources/iCalendarParser/Constant/Constant.swift
+++ b/Sources/iCalendarParser/Constant/Constant.swift
@@ -66,6 +66,8 @@ extension Constant {
 
         static let attachment: String = "ATTACH"
         static let categories: String = "CATEGORIES"
+        static let comment: String = "COMMENT"
+        static let contact: String = "CONTACT"
         static let created: String = "CREATED"
         static let classification: String = "CLASS"
         static let description: String = "DESCRIPTION"
@@ -82,6 +84,7 @@ extension Constant {
         static let recurrenceDates: String = "RDATE"
         static let recurrenceId: String = "RECURRENCE-ID"
         static let recurrenceRule: String = "RRULE"
+        static let resources: String = "RESOURCES"
         static let sequence: String = "SEQUENCE"
         static let status: String = "STATUS"
         static let summary: String = "SUMMARY"

--- a/Sources/iCalendarParser/Models/ICEvent.swift
+++ b/Sources/iCalendarParser/Models/ICEvent.swift
@@ -31,9 +31,18 @@ public struct ICEvent: ICComponentable {
     /// https://www.rfc-editor.org/rfc/rfc5545#section-3.8.1.3)
     public var classification: String?
 
-    // var comment: [String]?
+    /// Provides non-processing information intended to provide a comment to the calendar user.
+    ///
+    /// See more in [RFC 5545](
+    /// https://www.rfc-editor.org/rfc/rfc5545#section-3.8.1.4)
+    public var comments: [String]?
 
-    // var contact: [String]?
+    /// Represents contact information or alternately a reference to contact information associated with
+    /// the calendar component.
+    ///
+    /// See more in [RFC 5545](
+    /// https://www.rfc-editor.org/rfc/rfc5545#section-3.8.4.2)
+    public var contacts: [String]?
 
     /// Provides a more complete description of the calendar component
     /// than that provided by the "SUMMARY" property.
@@ -155,7 +164,11 @@ public struct ICEvent: ICComponentable {
 
     // var requestStatus
 
-    // var resources: [String]?
+    /// Defines the equipment or resources anticipated for an activity specified by a calendar component.
+    ///
+    /// See more in [RFC 5545](
+    /// https://www.rfc-editor.org/rfc/rfc5545#section-3.8.1.10)
+    public var resources: [String]?
 
     /// Defines the revision sequence number of the  calendar component within a sequence of revisions.
     ///
@@ -197,6 +210,8 @@ public struct ICEvent: ICComponentable {
         attendees: [ICAttendee]? = nil,
         categories: [String]? = nil,
         classification: String? = nil,
+        comments: [String]? = nil,
+        contacts: [String]? = nil,
         description: String? = nil,
         dtCreated: Date? = nil,
         dtEnd: ICDateTime? = nil,
@@ -208,6 +223,7 @@ public struct ICEvent: ICComponentable {
         organizer: String? = nil,
         priority: Int? = nil,
         recurrenceId: ICDateTime? = nil,
+        resources: [String]? = nil,
         sequence: Int? = nil,
         status: String? = nil,
         summary: String? = nil,
@@ -218,6 +234,8 @@ public struct ICEvent: ICComponentable {
         self.attendees = attendees
         self.categories = categories
         self.classification = classification
+        self.comments = comments
+        self.contacts = contacts
         self.description = description
         self.dtCreated = dtCreated
         self.dtEnd = dtEnd
@@ -229,6 +247,7 @@ public struct ICEvent: ICComponentable {
         self.organizer = organizer
         self.priority = priority
         self.recurrenceId = recurrenceId
+        self.resources = resources
         self.sequence = sequence
         self.status = status
         self.summary = summary

--- a/Sources/iCalendarParser/Parser/ICParser.swift
+++ b/Sources/iCalendarParser/Parser/ICParser.swift
@@ -155,6 +155,8 @@ public struct ICParser {
             event.attendees = component.buildAttendees(of: Constant.Property.attendee)
             event.categories = component.buildCategories(of: Constant.Property.categories)
             event.classification = component.buildProperty(of: Constant.Property.classification)
+            event.comments = component.buildCategories(of: Constant.Property.comment)
+            event.contacts = component.buildCategories(of: Constant.Property.contact)
             event.description = component.buildProperty(of: Constant.Property.description)
             event.dtCreated = component.buildProperty(of: Constant.Property.created)?.date
             event.dtEnd = component.buildProperty(of: Constant.Property.dtEnd)
@@ -165,6 +167,7 @@ public struct ICParser {
             event.organizer = component.buildProperty(of: Constant.Property.organizer)
             event.priority = component.buildProperty(of: Constant.Property.priority)
             event.recurrenceId = component.buildProperty(of: Constant.Property.recurrenceId)
+            event.resources = component.buildCategories(of: Constant.Property.resources)
             event.sequence = component.buildProperty(of: Constant.Property.sequence)
             event.status = component.buildProperty(of: Constant.Property.status)
             event.summary = component.buildProperty(of: Constant.Property.summary)

--- a/Tests/iCalendarParserTests/ICParserTests.swift
+++ b/Tests/iCalendarParserTests/ICParserTests.swift
@@ -67,4 +67,30 @@ final class ICParserTests: XCTestCase {
 
         XCTAssertEqual(event.categories, ["Board, Executive", "Work", "Personal"])
     }
+
+    func testEventTextListPropertiesSupportRepeatedPropertiesAndEscapedCommas() throws {
+        let iCalString = """
+        BEGIN:VCALENDAR\r
+        VERSION:2.0\r
+        PRODID:-//Example Inc//Calendar//EN\r
+        BEGIN:VEVENT\r
+        UID:text-list-test\r
+        DTSTAMP:20240728T120000Z\r
+        COMMENT:Bring projector\r
+        COMMENT:Confirm room\\, catering\r
+        CONTACT:Desk\\, Front,Security\r
+        CONTACT:Facilities\r
+        RESOURCES:Projector,Whiteboard\\, mobile\r
+        RESOURCES:Speakerphone\r
+        END:VEVENT\r
+        END:VCALENDAR
+        """
+
+        let calendar = try XCTUnwrap(sut.calendar(from: iCalString))
+        let event = try XCTUnwrap(calendar.events.first)
+
+        XCTAssertEqual(event.comments, ["Bring projector", "Confirm room, catering"])
+        XCTAssertEqual(event.contacts, ["Desk, Front", "Security", "Facilities"])
+        XCTAssertEqual(event.resources, ["Projector", "Whiteboard, mobile", "Speakerphone"])
+    }
 }


### PR DESCRIPTION
## Summary

Adds public ICEvent accessors for RFC 5545 event text-list properties:

- comments from COMMENT
- contacts from CONTACT
- resources from RESOURCES

The parser now populates these fields using the same repeated-property and escaped-comma behavior already used for CATEGORIES.

## Validation

- swift test
- make lint