### PR TITLE
feat: expose event recurrence date properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,51 @@ iCalendarParser is currently not feature complete yet. While it requires an addi
 
 ## TODO
 
-- Parse To-Do, Journal, Free/Busy, and Alarm components
-- Add additional properties in `ICEvent`
+- [ ] Components
+  - [x] Parse `VEVENT`
+  - [x] Parse `VTIMEZONE`
+  - [ ] Parse `VTODO`
+  - [ ] Parse `VJOURNAL`
+  - [ ] Parse `VFREEBUSY`
+  - [ ] Parse `VALARM`
+- [ ] `VEVENT` properties
+  - [x] Add `COMMENT`, `CONTACT`, and `RESOURCES`
+  - [x] Add `EXDATE` and `RDATE`
+  - [ ] Add `DURATION`
+  - [ ] Add `ATTACH`
+  - [ ] Add `GEO`
+  - [ ] Add `RELATED-TO`
+  - [ ] Add `REQUEST-STATUS`
+- [ ] Recurrence
+  - [x] Parse basic `RRULE`
+  - [ ] Expand recurring events into instances
+  - [ ] Apply `EXDATE`
+  - [ ] Apply `RDATE`
+  - [ ] Handle `RECURRENCE-ID` overrides
+- [ ] Property parameters
+  - [ ] Preserve common parameters on parsed properties
+  - [ ] Support quoted parameter values
+  - [ ] Support multi-value parameters
+  - [ ] Support `ALTREP`, `LANGUAGE`, `CN`, `ROLE`, `PARTSTAT`, `RSVP`, `TZID`, and `VALUE`
+- [ ] Value types
+  - [x] Parse `DATE`
+  - [x] Parse `DATE-TIME`
+  - [ ] Parse `DURATION`
+  - [ ] Parse `PERIOD`
+  - [ ] Parse `URI`
+  - [ ] Parse `UTC-OFFSET`
+- [ ] Serialization
+  - [ ] Format calendars back to valid `.ics`
+  - [ ] Fold long lines correctly
+  - [ ] Escape text values correctly
+- [ ] Validation
+  - [ ] Validate required properties per component
+  - [ ] Validate mutually exclusive properties, such as `DTEND` and `DURATION`
+  - [ ] Validate property cardinality rules
+- [ ] Compatibility
+  - [ ] Preserve unknown standard properties
+  - [ ] Preserve `X-` properties and parameters
+  - [ ] Add fixture coverage from real-world calendars
 
 ## Contributing
 

--- a/Sources/iCalendarParser/Builder/PropertyBuilder.swift
+++ b/Sources/iCalendarParser/Builder/PropertyBuilder.swift
@@ -25,6 +25,18 @@ struct PropertyBuilder {
         }
     }
 
+    static func buildDateTimes(
+        from props: [ICProperty]
+    ) -> [ICDateTime] {
+        props.flatMap { prop in
+            prop.value
+                .components(separatedBy: ",")
+                .compactMap { value in
+                    buildDateTime(from: (name: prop.name, value: value))
+                }
+        }
+    }
+
     // swiftlint:disable:next cyclomatic_complexity
     static func buildRRule(
         from prop: ICProperty

--- a/Sources/iCalendarParser/Models/ICComponent.swift
+++ b/Sources/iCalendarParser/Models/ICComponent.swift
@@ -89,6 +89,18 @@ struct ICComponent {
         return PropertyBuilder.buildCategories(from: props)
     }
 
+    /// Returns date-time values from all matching properties.
+    func buildDateTimes(
+        of name: String
+    ) -> [ICDateTime]? {
+        guard let props = getProperties(name: name), !props.isEmpty else {
+            return nil
+        }
+
+        let dateTimes = PropertyBuilder.buildDateTimes(from: props)
+        return dateTimes.isEmpty ? nil : dateTimes
+    }
+
     /// Returns all non-standard properties if exists
     func getNonStandardProperties() -> [String: String]? {
         var dict = [String: String]()

--- a/Sources/iCalendarParser/Models/ICEvent.swift
+++ b/Sources/iCalendarParser/Models/ICEvent.swift
@@ -92,12 +92,12 @@ public struct ICEvent: ICComponentable {
     // https://www.rfc-editor.org/rfc/rfc5545#section-3.8.2.5)
     // var duration: ICDuration?
 
-    // The list of DATE-TIME exceptions for recurring events, to-dos, journal entries,
-    // or time zone definitions.
-    //
-    // See more in [RFC 5545](
-    // https://www.rfc-editor.org/rfc/rfc5545#section-3.8.5.1)
-    // var exceptionDates: [Date]?
+    /// The list of DATE-TIME exceptions for recurring events, to-dos, journal entries,
+    /// or time zone definitions.
+    ///
+    /// See more in [RFC 5545](
+    /// https://www.rfc-editor.org/rfc/rfc5545#section-3.8.5.1)
+    public var exceptionDates: [ICDateTime]?
 
     // Specifies information related to the global position for the activity specified by
     // a calendar component.
@@ -148,11 +148,11 @@ public struct ICEvent: ICComponentable {
     /// https://www.rfc-editor.org/rfc/rfc5545#section-3.8.4.4)
     public var recurrenceId: ICDateTime?
 
-    // The list of DATE-TIME values for recurring events, to-dos, journal entries, or time zone definitions.
-    //
-    // See more in [RFC 5545](
-    // https://www.rfc-editor.org/rfc/rfc5545#section-3.8.5.2)
-    // var recurrenceDates: [ICDateTime]?
+    /// The list of DATE-TIME values for recurring events, to-dos, journal entries, or time zone definitions.
+    ///
+    /// See more in [RFC 5545](
+    /// https://www.rfc-editor.org/rfc/rfc5545#section-3.8.5.2)
+    public var recurrenceDates: [ICDateTime]?
 
     // A rule or repeating pattern for recurring events, to-dos, journal entries, or time zone definitions.
     //
@@ -217,11 +217,13 @@ public struct ICEvent: ICComponentable {
         dtEnd: ICDateTime? = nil,
         dtStamp: Date = Date(),
         dtStart: ICDateTime? = nil,
+        exceptionDates: [ICDateTime]? = nil,
         lastModified: Date? = nil,
         location: String? = nil,
         nonStandardProperties: [String: String]? = nil,
         organizer: String? = nil,
         priority: Int? = nil,
+        recurrenceDates: [ICDateTime]? = nil,
         recurrenceId: ICDateTime? = nil,
         resources: [String]? = nil,
         sequence: Int? = nil,
@@ -241,11 +243,13 @@ public struct ICEvent: ICComponentable {
         self.dtEnd = dtEnd
         self.dtStamp = dtStamp
         self.dtStart = dtStart
+        self.exceptionDates = exceptionDates
         self.lastModified = lastModified
         self.location = location
         self.nonStandardProperties = nonStandardProperties
         self.organizer = organizer
         self.priority = priority
+        self.recurrenceDates = recurrenceDates
         self.recurrenceId = recurrenceId
         self.resources = resources
         self.sequence = sequence

--- a/Sources/iCalendarParser/Parser/ICParser.swift
+++ b/Sources/iCalendarParser/Parser/ICParser.swift
@@ -162,10 +162,12 @@ public struct ICParser {
             event.dtEnd = component.buildProperty(of: Constant.Property.dtEnd)
             event.dtStamp = component.buildProperty(of: Constant.Property.dtStamp)?.date ?? Date()
             event.dtStart = component.buildProperty(of: Constant.Property.dtStart)
+            event.exceptionDates = component.buildDateTimes(of: Constant.Property.exceptionDates)
             event.lastModified = component.buildProperty(of: Constant.Property.lastModified)?.date
             event.location = component.buildProperty(of: Constant.Property.location)
             event.organizer = component.buildProperty(of: Constant.Property.organizer)
             event.priority = component.buildProperty(of: Constant.Property.priority)
+            event.recurrenceDates = component.buildDateTimes(of: Constant.Property.recurrenceDates)
             event.recurrenceId = component.buildProperty(of: Constant.Property.recurrenceId)
             event.resources = component.buildCategories(of: Constant.Property.resources)
             event.sequence = component.buildProperty(of: Constant.Property.sequence)

--- a/Tests/iCalendarParserTests/ICParserTests.swift
+++ b/Tests/iCalendarParserTests/ICParserTests.swift
@@ -93,4 +93,35 @@ final class ICParserTests: XCTestCase {
         XCTAssertEqual(event.contacts, ["Desk, Front", "Security", "Facilities"])
         XCTAssertEqual(event.resources, ["Projector", "Whiteboard, mobile", "Speakerphone"])
     }
+
+    func testEventRecurrenceDatePropertiesSupportRepeatedPropertiesAndCommaSeparatedValues() throws {
+        let iCalString = """
+        BEGIN:VCALENDAR\r
+        VERSION:2.0\r
+        PRODID:-//Example Inc//Calendar//EN\r
+        BEGIN:VEVENT\r
+        UID:recurrence-dates-test\r
+        DTSTAMP:20240728T120000Z\r
+        EXDATE:20240801T120000Z,20240802T120000Z\r
+        EXDATE;VALUE=DATE:20240803\r
+        RDATE:20240805T120000Z\r
+        RDATE;VALUE=DATE:20240806,20240807\r
+        END:VEVENT\r
+        END:VCALENDAR
+        """
+
+        let calendar = try XCTUnwrap(sut.calendar(from: iCalString))
+        let event = try XCTUnwrap(calendar.events.first)
+
+        XCTAssertEqual(event.exceptionDates?.map(\.type), [.dateTime, .dateTime, .date])
+        XCTAssertEqual(event.recurrenceDates?.map(\.type), [.dateTime, .date, .date])
+        XCTAssertEqual(
+            event.exceptionDates?.map { $0.type.dateFormatter(tzId: $0.tzId).string(from: $0.date) },
+            ["20240801T120000Z", "20240802T120000Z", "20240803"]
+        )
+        XCTAssertEqual(
+            event.recurrenceDates?.map { $0.type.dateFormatter(tzId: $0.tzId).string(from: $0.date) },
+            ["20240805T120000Z", "20240806", "20240807"]
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Adds public ICEvent accessors for recurrence date properties:

- exceptionDates from EXDATE
- recurrenceDates from RDATE

The parser now handles repeated EXDATE/RDATE properties and comma-separated DATE or DATE-TIME values. The README RFC checklist was also expanded and marks EXDATE/RDATE parsing as complete.

## Validation

- swift test
- make lint