### PR TITLE
feat: expose event duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ iCalendarParser is currently not feature complete yet. While it requires an addi
 - [ ] `VEVENT` properties
   - [x] Add `COMMENT`, `CONTACT`, and `RESOURCES`
   - [x] Add `EXDATE` and `RDATE`
-  - [ ] Add `DURATION`
+  - [x] Add `DURATION`
   - [ ] Add `ATTACH`
   - [ ] Add `GEO`
   - [ ] Add `RELATED-TO`

--- a/Sources/iCalendarParser/Builder/PropertyBuilder.swift
+++ b/Sources/iCalendarParser/Builder/PropertyBuilder.swift
@@ -37,6 +37,12 @@ struct PropertyBuilder {
         }
     }
 
+    static func buildDuration(
+        from prop: ICProperty
+    ) -> ICDuration? {
+        ICDuration(rawValue: prop.value)
+    }
+
     // swiftlint:disable:next cyclomatic_complexity
     static func buildRRule(
         from prop: ICProperty

--- a/Sources/iCalendarParser/Models/ICComponent.swift
+++ b/Sources/iCalendarParser/Models/ICComponent.swift
@@ -67,6 +67,17 @@ struct ICComponent {
         return PropertyBuilder.buildRRule(from: prop)
     }
 
+    /// Returns `ICDuration` from properties
+    func buildProperty(
+        of name: String
+    ) -> ICDuration? {
+        guard let prop = getProperty(name: name) else {
+            return nil
+        }
+
+        return PropertyBuilder.buildDuration(from: prop)
+    }
+
     /// Returns `[Attendee]` from properties
     func buildAttendees(
         of name: String

--- a/Sources/iCalendarParser/Models/ICDuration.swift
+++ b/Sources/iCalendarParser/Models/ICDuration.swift
@@ -1,0 +1,183 @@
+import Foundation
+
+/// A positive or negative duration of time.
+///
+/// See more in [RFC 5545](
+/// https://www.rfc-editor.org/rfc/rfc5545#section-3.3.6)
+public struct ICDuration: Equatable {
+
+    public var isNegative: Bool
+    public var weeks: Int?
+    public var days: Int?
+    public var hours: Int?
+    public var minutes: Int?
+    public var seconds: Int?
+    public var rawValue: String
+
+    public init(
+        isNegative: Bool = false,
+        weeks: Int? = nil,
+        days: Int? = nil,
+        hours: Int? = nil,
+        minutes: Int? = nil,
+        seconds: Int? = nil,
+        rawValue: String
+    ) {
+        self.isNegative = isNegative
+        self.weeks = weeks
+        self.days = days
+        self.hours = hours
+        self.minutes = minutes
+        self.seconds = seconds
+        self.rawValue = rawValue
+    }
+
+    public init?(
+        rawValue: String
+    ) {
+        var value = rawValue
+        var isNegative = false
+
+        if value.hasPrefix("+") || value.hasPrefix("-") {
+            isNegative = value.hasPrefix("-")
+            value.removeFirst()
+        }
+
+        guard value.hasPrefix("P") else {
+            return nil
+        }
+        value.removeFirst()
+
+        if let weeks = Self.parseWeeks(value) {
+            self.init(isNegative: isNegative, weeks: weeks, rawValue: rawValue)
+            return
+        }
+
+        guard let dateTime = Self.parseDateTime(value) else {
+            return nil
+        }
+
+        self.init(
+            isNegative: isNegative,
+            days: dateTime.days,
+            hours: dateTime.hours,
+            minutes: dateTime.minutes,
+            seconds: dateTime.seconds,
+            rawValue: rawValue
+        )
+    }
+
+    private struct DurationDateTime {
+        var days: Int?
+        var hours: Int?
+        var minutes: Int?
+        var seconds: Int?
+    }
+
+    private static func parseWeeks(
+        _ value: String
+    ) -> Int? {
+        guard value.hasSuffix("W") else {
+            return nil
+        }
+
+        let weekValue = String(value.dropLast())
+        guard !weekValue.isEmpty else {
+            return nil
+        }
+
+        return Int(weekValue)
+    }
+
+    private static func parseDateTime(
+        _ value: String
+    ) -> DurationDateTime? {
+        let parts = value.components(separatedBy: "T")
+        guard parts.count <= 2 else {
+            return nil
+        }
+
+        let datePart = parts[0]
+        let timePart = parts.count == 2 ? parts[1] : nil
+
+        if parts.count == 2, timePart?.isEmpty == true {
+            return nil
+        }
+
+        let days = parseDays(datePart)
+        let time = parseTime(timePart)
+
+        guard days != nil || time != nil else {
+            return nil
+        }
+
+        return DurationDateTime(
+            days: days,
+            hours: time?.hours,
+            minutes: time?.minutes,
+            seconds: time?.seconds
+        )
+    }
+
+    private static func parseDays(
+        _ value: String
+    ) -> Int? {
+        guard !value.isEmpty else {
+            return nil
+        }
+
+        guard value.hasSuffix("D") else {
+            return nil
+        }
+
+        let dayValue = String(value.dropLast())
+        guard !dayValue.isEmpty else {
+            return nil
+        }
+
+        return Int(dayValue)
+    }
+
+    private static func parseTime(
+        _ value: String?
+    ) -> DurationDateTime? {
+        guard let value, !value.isEmpty else {
+            return nil
+        }
+
+        var remaining = value
+        let hours = parseComponent("H", from: &remaining)
+        let minutes = parseComponent("M", from: &remaining)
+        let seconds = parseComponent("S", from: &remaining)
+
+        guard remaining.isEmpty, hours != nil || minutes != nil || seconds != nil else {
+            return nil
+        }
+
+        return DurationDateTime(hours: hours, minutes: minutes, seconds: seconds)
+    }
+
+    private static func parseComponent(
+        _ designator: Character,
+        from value: inout String
+    ) -> Int? {
+        var digits = ""
+
+        while let character = value.first, character.isNumber {
+            digits.append(character)
+            value.removeFirst()
+        }
+
+        guard !digits.isEmpty else {
+            return nil
+        }
+
+        guard value.first == designator else {
+            value = digits + value
+            return nil
+        }
+
+        value.removeFirst()
+        return Int(digits)
+    }
+}

--- a/Sources/iCalendarParser/Models/ICEvent.swift
+++ b/Sources/iCalendarParser/Models/ICEvent.swift
@@ -86,11 +86,11 @@ public struct ICEvent: ICComponentable {
     /// https://www.rfc-editor.org/rfc/rfc5545#section-3.8.2.4)
     public var dtStart: ICDateTime?
 
-    // A positive duration of time.
-    //
-    // See more in [RFC 5545](
-    // https://www.rfc-editor.org/rfc/rfc5545#section-3.8.2.5)
-    // var duration: ICDuration?
+    /// A positive duration of time.
+    ///
+    /// See more in [RFC 5545](
+    /// https://www.rfc-editor.org/rfc/rfc5545#section-3.8.2.5)
+    public var duration: ICDuration?
 
     /// The list of DATE-TIME exceptions for recurring events, to-dos, journal entries,
     /// or time zone definitions.
@@ -217,6 +217,7 @@ public struct ICEvent: ICComponentable {
         dtEnd: ICDateTime? = nil,
         dtStamp: Date = Date(),
         dtStart: ICDateTime? = nil,
+        duration: ICDuration? = nil,
         exceptionDates: [ICDateTime]? = nil,
         lastModified: Date? = nil,
         location: String? = nil,
@@ -243,6 +244,7 @@ public struct ICEvent: ICComponentable {
         self.dtEnd = dtEnd
         self.dtStamp = dtStamp
         self.dtStart = dtStart
+        self.duration = duration
         self.exceptionDates = exceptionDates
         self.lastModified = lastModified
         self.location = location

--- a/Sources/iCalendarParser/Parser/ICParser.swift
+++ b/Sources/iCalendarParser/Parser/ICParser.swift
@@ -162,6 +162,7 @@ public struct ICParser {
             event.dtEnd = component.buildProperty(of: Constant.Property.dtEnd)
             event.dtStamp = component.buildProperty(of: Constant.Property.dtStamp)?.date ?? Date()
             event.dtStart = component.buildProperty(of: Constant.Property.dtStart)
+            event.duration = component.buildProperty(of: Constant.Property.duration)
             event.exceptionDates = component.buildDateTimes(of: Constant.Property.exceptionDates)
             event.lastModified = component.buildProperty(of: Constant.Property.lastModified)?.date
             event.location = component.buildProperty(of: Constant.Property.location)

--- a/Tests/iCalendarParserTests/DurationTests.swift
+++ b/Tests/iCalendarParserTests/DurationTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import iCalendarParser
+
+final class DurationTests: XCTestCase {
+
+    func testBuildWeekDuration() throws {
+        let duration = try XCTUnwrap(PropertyBuilder.buildDuration(from: ICProperty("DURATION", "P2W")))
+
+        XCTAssertFalse(duration.isNegative)
+        XCTAssertEqual(duration.weeks, 2)
+        XCTAssertNil(duration.days)
+        XCTAssertNil(duration.hours)
+        XCTAssertNil(duration.minutes)
+        XCTAssertNil(duration.seconds)
+        XCTAssertEqual(duration.rawValue, "P2W")
+    }
+
+    func testBuildDateTimeDuration() throws {
+        let duration = try XCTUnwrap(PropertyBuilder.buildDuration(from: ICProperty("DURATION", "P1DT2H30M15S")))
+
+        XCTAssertFalse(duration.isNegative)
+        XCTAssertNil(duration.weeks)
+        XCTAssertEqual(duration.days, 1)
+        XCTAssertEqual(duration.hours, 2)
+        XCTAssertEqual(duration.minutes, 30)
+        XCTAssertEqual(duration.seconds, 15)
+        XCTAssertEqual(duration.rawValue, "P1DT2H30M15S")
+    }
+
+    func testBuildTimeOnlyDuration() throws {
+        let duration = try XCTUnwrap(PropertyBuilder.buildDuration(from: ICProperty("DURATION", "PT45M")))
+
+        XCTAssertNil(duration.days)
+        XCTAssertEqual(duration.minutes, 45)
+    }
+
+    func testBuildSignedDuration() throws {
+        let duration = try XCTUnwrap(PropertyBuilder.buildDuration(from: ICProperty("DURATION", "-PT15M")))
+
+        XCTAssertTrue(duration.isNegative)
+        XCTAssertEqual(duration.minutes, 15)
+    }
+
+    func testInvalidDurationReturnsNil() {
+        XCTAssertNil(PropertyBuilder.buildDuration(from: ICProperty("DURATION", "P1M")))
+        XCTAssertNil(PropertyBuilder.buildDuration(from: ICProperty("DURATION", "PT1M2H")))
+        XCTAssertNil(PropertyBuilder.buildDuration(from: ICProperty("DURATION", "P1DT")))
+    }
+}

--- a/Tests/iCalendarParserTests/ICParserTests.swift
+++ b/Tests/iCalendarParserTests/ICParserTests.swift
@@ -124,4 +124,28 @@ final class ICParserTests: XCTestCase {
             ["20240805T120000Z", "20240806", "20240807"]
         )
     }
+
+    func testEventDuration() throws {
+        let iCalString = """
+        BEGIN:VCALENDAR\r
+        VERSION:2.0\r
+        PRODID:-//Example Inc//Calendar//EN\r
+        BEGIN:VEVENT\r
+        UID:duration-test\r
+        DTSTAMP:20240728T120000Z\r
+        DTSTART:20240801T120000Z\r
+        DURATION:P1DT2H30M\r
+        END:VEVENT\r
+        END:VCALENDAR
+        """
+
+        let calendar = try XCTUnwrap(sut.calendar(from: iCalString))
+        let event = try XCTUnwrap(calendar.events.first)
+        let duration = try XCTUnwrap(event.duration)
+
+        XCTAssertEqual(duration.days, 1)
+        XCTAssertEqual(duration.hours, 2)
+        XCTAssertEqual(duration.minutes, 30)
+        XCTAssertNil(duration.seconds)
+    }
 }


### PR DESCRIPTION
## Summary

Adds public ICEvent support for DURATION values:

- introduces ICDuration for RFC 5545 duration strings
- parses DURATION into ICEvent.duration
- covers week, date-time, time-only, signed, invalid, and event parser cases

The README RFC checklist now marks DURATION support as complete.

## Validation

- swift test
- make lint