### PR TITLE
feat: parse property parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ iCalendarParser is currently not feature complete yet. While it requires an addi
   - [ ] Apply `RDATE`
   - [ ] Handle `RECURRENCE-ID` overrides
 - [ ] Property parameters
-  - [ ] Preserve common parameters on parsed properties
-  - [ ] Support quoted parameter values
-  - [ ] Support multi-value parameters
+  - [x] Preserve common parameters on parsed properties
+  - [x] Support quoted parameter values
+  - [x] Support multi-value parameters
   - [ ] Support `ALTREP`, `LANGUAGE`, `CN`, `ROLE`, `PARTSTAT`, `RSVP`, `TZID`, and `VALUE`
 - [ ] Value types
   - [x] Parse `DATE`

--- a/Sources/iCalendarParser/Builder/PropertyBuilder.swift
+++ b/Sources/iCalendarParser/Builder/PropertyBuilder.swift
@@ -7,9 +7,8 @@ struct PropertyBuilder {
     static func buildDateTime(
         from prop: ICProperty
     ) -> ICDateTime? {
-        let params = getParamsOfValue(from: prop.name)
-        let valueType = getDateTimeType(from: params)
-        let tzid = getTimeZoneId(from: params)
+        let valueType = getDateTimeType(from: prop.parameters)
+        let tzid = getTimeZoneId(from: prop.parameters)
 
         guard
             let date = valueType.dateFormatter(tzId: tzid).date(from: prop.value)
@@ -32,7 +31,7 @@ struct PropertyBuilder {
             prop.value
                 .components(separatedBy: ",")
                 .compactMap { value in
-                    buildDateTime(from: (name: prop.name, value: value))
+                    buildDateTime(from: ICProperty(prop.name, value))
                 }
         }
     }
@@ -47,7 +46,7 @@ struct PropertyBuilder {
     static func buildRRule(
         from prop: ICProperty
     ) -> ICRRule? {
-        let params = getParamsOfValue(from: prop.value)
+        let params = getProperties(from: prop.value)
         let frequencyProperty = params
             .filter { $0.name == Constant.Property.frequency }
             .first
@@ -101,18 +100,17 @@ struct PropertyBuilder {
         return props.map { prop -> ICAttendee in
             var attendee = ICAttendee()
 
-            let params = getParamsOfValue(from: prop.name)
-            params.forEach { property in
-                switch property.name {
+            prop.parameters.forEach { parameter in
+                switch parameter.name {
                 case Constant.Property.cname:
-                    attendee.cname = property.value
+                    attendee.cname = parameter.value
                 case Constant.Property.partstat:
-                    attendee.participationStatus = ParticipationStatus(rawValue: property.value)
+                    attendee.participationStatus = ParticipationStatus(rawValue: parameter.value)
                 default:
                     if attendee.nonStandardProperties == nil {
                         attendee.nonStandardProperties = [:]
                     }
-                    attendee.nonStandardProperties?[property.name] = property.value
+                    attendee.nonStandardProperties?[parameter.name] = parameter.value
                 }
             }
 
@@ -130,20 +128,20 @@ struct PropertyBuilder {
     // MARK: - Private functions
 
     /// Returns an array of params for the given value
-    private static func getParamsOfValue(
+    private static func getProperties(
         from value: String
     ) -> [ICProperty] {
-        return value.components(separatedBy: ";")
-            .map { $0.components(separatedBy: "=") }
+        return ICProperty.split(value, separator: ";")
+            .map { ICProperty.split($0, separator: "=", maxSplits: 1) }
             .filter { $0.count > 1 }
-            .map { ($0[0], $0[1]) }
+            .map { ICProperty($0[0], $0[1]) }
     }
 
     /// Returns `ICDateTimeType` from the given properties
     ///
     /// The default value is `.dateTime` if no property is found
     private static func getDateTimeType(
-        from params: [ICProperty]
+        from params: [ICParameter]
     ) -> DateTimeType {
         guard
             let valueType = params.first(where: {
@@ -163,7 +161,7 @@ struct PropertyBuilder {
 
     /// Returns the ID for Timezone component
     private static func getTimeZoneId(
-        from parameters: [ICProperty]
+        from parameters: [ICParameter]
     ) -> String? {
         return parameters.first(where: {
             $0.name == Constant.Property.tzId

--- a/Sources/iCalendarParser/Models/ICComponent.swift
+++ b/Sources/iCalendarParser/Models/ICComponent.swift
@@ -9,7 +9,7 @@ struct ICComponent {
         name: String
     ) -> ICProperty? {
         return properties
-            .filter { $0.name.hasPrefix(name) }
+            .filter { $0.baseName == name }
             .first
     }
 
@@ -18,7 +18,7 @@ struct ICComponent {
         name: String
     ) -> [ICProperty]? {
         return properties
-            .filter { $0.name.hasPrefix(name) }
+            .filter { $0.baseName == name }
     }
 
     // MARK: - Build property
@@ -135,7 +135,7 @@ struct ICComponent {
         from elements: [ICProperty]
     ) -> ICProperty? {
         return elements
-            .filter { $0.name.hasPrefix(name) }
+            .filter { $0.baseName == name }
             .first
     }
 }

--- a/Sources/iCalendarParser/Models/ICParameter.swift
+++ b/Sources/iCalendarParser/Models/ICParameter.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+struct ICParameter: Equatable {
+    let name: String
+    let values: [String]
+
+    var value: String {
+        values.joined(separator: ",")
+    }
+
+    init(
+        name: String,
+        values: [String]
+    ) {
+        self.name = name
+        self.values = values
+    }
+}

--- a/Sources/iCalendarParser/Models/ICProperty.swift
+++ b/Sources/iCalendarParser/Models/ICProperty.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+struct ICProperty: Equatable {
+    let name: String
+    let value: String
+    let parameters: [ICParameter]
+
+    var baseName: String {
+        name.split(separator: ";", maxSplits: 1).first.map(String.init) ?? name
+    }
+
+    init(
+        _ name: String,
+        _ value: String
+    ) {
+        self.name = name
+        self.value = value
+        self.parameters = Self.parameters(from: name)
+    }
+
+    private static func parameters(
+        from name: String
+    ) -> [ICParameter] {
+        split(name, separator: ";")
+            .dropFirst()
+            .compactMap { parameter in
+                let parts = split(parameter, separator: "=", maxSplits: 1)
+
+                guard parts.count == 2 else {
+                    return nil
+                }
+
+                return ICParameter(
+                    name: parts[0],
+                    values: split(parts[1], separator: ",").map(unquote)
+                )
+            }
+    }
+
+    static func split(
+        _ value: String,
+        separator: Character,
+        maxSplits: Int = .max
+    ) -> [String] {
+        var result = [String]()
+        var current = ""
+        var isQuoted = false
+        var splitCount = 0
+
+        for character in value {
+            if character == "\"" {
+                isQuoted.toggle()
+                current.append(character)
+            } else if character == separator,
+                      !isQuoted,
+                      splitCount < maxSplits {
+                result.append(current)
+                current = ""
+                splitCount += 1
+            } else {
+                current.append(character)
+            }
+        }
+
+        result.append(current)
+        return result
+    }
+
+    private static func unquote(
+        _ value: String
+    ) -> String {
+        guard value.hasPrefix("\""), value.hasSuffix("\"") else {
+            return value
+        }
+
+        return String(value.dropFirst().dropLast())
+    }
+}

--- a/Sources/iCalendarParser/Parser/ICParser.swift
+++ b/Sources/iCalendarParser/Parser/ICParser.swift
@@ -1,7 +1,5 @@
 import Foundation
 
-typealias ICProperty = (name: String, value: String)
-
 public struct ICParser {
 
     public init() {}
@@ -73,9 +71,9 @@ public struct ICParser {
         // Split by \n
         let properties: [ICProperty] = unfoldedICS
             .components(separatedBy: "\n")
-            .map { $0.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: true) }
-            .filter { $0.count > 1 }
-            .map { (String($0[0]), String($0[1])) }
+            .map { ICProperty.split($0, separator: ":", maxSplits: 1) }
+            .filter { $0.count > 1 && !$0[0].isEmpty }
+            .map { ICProperty($0[0], $0[1]) }
 
         return properties
     }
@@ -85,7 +83,7 @@ public struct ICParser {
         from elements: [ICProperty]
     ) -> ICProperty? {
         elements
-            .filter { $0.name.hasPrefix(name) }
+            .filter { $0.baseName == name }
             .first
     }
 
@@ -102,8 +100,8 @@ public struct ICParser {
     ) -> [ICComponent] {
 
         var found = [ICComponent]()
-        var currentComponent: [(String, String)]?
-        var childComponent: [(String, String)]?
+        var currentComponent: [ICProperty]?
+        var childComponent: [ICProperty]?
 
         for element in elements {
             if element.name == Constant.Property.begin,
@@ -246,7 +244,7 @@ public struct ICParser {
 
         guard
             let dtStart = PropertyBuilder.buildDateTime(
-                from: (name: Constant.Property.dtStart, value: dtStartValue)
+                from: ICProperty(Constant.Property.dtStart, dtStartValue)
             )?.date
         else { return nil }
 

--- a/Tests/iCalendarParserTests/GetPropertiesTests.swift
+++ b/Tests/iCalendarParserTests/GetPropertiesTests.swift
@@ -52,4 +52,35 @@ final class GetPropertiesTests: XCTestCase {
 
         XCTAssertEqual(properties.first?.value, "HelloWorld")
     }
+
+    func testParsesQuotedParameterValues() throws {
+        let rawIcs = #"ATTENDEE;CN="Doe, John";ROLE=REQ-PARTICIPANT:mailto:john@example.com"#
+
+        let property = try XCTUnwrap(ICParser().getProperties(from: rawIcs).first)
+
+        XCTAssertEqual(property.baseName, "ATTENDEE")
+        XCTAssertEqual(property.parameters.first(where: { $0.name == "CN" })?.value, "Doe, John")
+        XCTAssertEqual(
+            property.parameters.first(where: { $0.name == "ROLE" })?.value,
+            "REQ-PARTICIPANT"
+        )
+    }
+
+    func testParsesMultiValueParameterValues() throws {
+        let rawIcs = #"ATTENDEE;MEMBER="mailto:a@example.com","mailto:b@example.com":mailto:c@example.com"#
+
+        let property = try XCTUnwrap(ICParser().getProperties(from: rawIcs).first)
+        let member = try XCTUnwrap(property.parameters.first(where: { $0.name == "MEMBER" }))
+
+        XCTAssertEqual(member.values, ["mailto:a@example.com", "mailto:b@example.com"])
+    }
+
+    func testParsesColonInsideQuotedParameterValue() throws {
+        let rawIcs = #"ATTENDEE;CN="Team: Calendar":mailto:team@example.com"#
+
+        let property = try XCTUnwrap(ICParser().getProperties(from: rawIcs).first)
+
+        XCTAssertEqual(property.value, "mailto:team@example.com")
+        XCTAssertEqual(property.parameters.first(where: { $0.name == "CN" })?.value, "Team: Calendar")
+    }
 }


### PR DESCRIPTION
## Summary
- add parsed property and parameter models
- preserve quoted and multi-value iCalendar property parameters
- use parsed parameters for date/time and attendee building
- match properties by base name instead of raw prefix

## Validation
- swift test
- swiftlint lint --quiet