### PR TITLE
feat: expose property parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ iCalendarParser is currently not feature complete yet. While it requires an addi
   - [x] Preserve common parameters on parsed properties
   - [x] Support quoted parameter values
   - [x] Support multi-value parameters
-  - [ ] Support `ALTREP`, `LANGUAGE`, `CN`, `ROLE`, `PARTSTAT`, `RSVP`, `TZID`, and `VALUE`
+  - [x] Support `ALTREP`, `LANGUAGE`, `CN`, `ROLE`, `PARTSTAT`, `RSVP`, `TZID`, and `VALUE`
 - [ ] Value types
   - [x] Parse `DATE`
   - [x] Parse `DATE-TIME`

--- a/Sources/iCalendarParser/Builder/PropertyBuilder.swift
+++ b/Sources/iCalendarParser/Builder/PropertyBuilder.swift
@@ -99,6 +99,7 @@ struct PropertyBuilder {
     ) -> [ICAttendee]? {
         return props.map { prop -> ICAttendee in
             var attendee = ICAttendee()
+            attendee.parameters = prop.parameters
 
             prop.parameters.forEach { parameter in
                 switch parameter.name {
@@ -106,6 +107,18 @@ struct PropertyBuilder {
                     attendee.cname = parameter.value
                 case Constant.Property.partstat:
                     attendee.participationStatus = ParticipationStatus(rawValue: parameter.value)
+                case Constant.Property.role:
+                    attendee.role = parameter.value
+                    if attendee.nonStandardProperties == nil {
+                        attendee.nonStandardProperties = [:]
+                    }
+                    attendee.nonStandardProperties?[parameter.name] = parameter.value
+                case Constant.Property.rsvp:
+                    attendee.rsvp = parameter.value.uppercased() == "TRUE"
+                    if attendee.nonStandardProperties == nil {
+                        attendee.nonStandardProperties = [:]
+                    }
+                    attendee.nonStandardProperties?[parameter.name] = parameter.value
                 default:
                     if attendee.nonStandardProperties == nil {
                         attendee.nonStandardProperties = [:]

--- a/Sources/iCalendarParser/Models/ICAttendee.swift
+++ b/Sources/iCalendarParser/Models/ICAttendee.swift
@@ -11,18 +11,33 @@ public struct ICAttendee {
 
     public var nonStandardProperties: [String: String]?
 
+    /// Parsed parameters from the `ATTENDEE` property.
+    public var parameters: [ICParameter]?
+
     /// Participation status of attendee
     public var participationStatus: ParticipationStatus?
+
+    /// Expected participation role of attendee.
+    public var role: String?
+
+    /// RSVP expectation for attendee.
+    public var rsvp: Bool?
 
     public init(
         cname: String? = nil,
         email: String? = nil,
         nonStandardProperties: [String: String]? = nil,
-        participationStatus: ParticipationStatus? = nil
+        parameters: [ICParameter]? = nil,
+        participationStatus: ParticipationStatus? = nil,
+        role: String? = nil,
+        rsvp: Bool? = nil
     ) {
         self.cname = cname
         self.email = email
         self.nonStandardProperties = nonStandardProperties
+        self.parameters = parameters
         self.participationStatus = participationStatus
+        self.role = role
+        self.rsvp = rsvp
     }
 }

--- a/Sources/iCalendarParser/Models/ICComponent.swift
+++ b/Sources/iCalendarParser/Models/ICComponent.swift
@@ -4,6 +4,13 @@ struct ICComponent {
     let properties: [ICProperty]
     let childProperties: [ICProperty]
 
+    var contentProperties: [ICProperty] {
+        properties.filter {
+            $0.baseName != Constant.Property.begin &&
+                $0.baseName != Constant.Property.end
+        }
+    }
+
     /// Returns a property that matches the name
     func getProperty(
         name: String

--- a/Sources/iCalendarParser/Models/ICEvent.swift
+++ b/Sources/iCalendarParser/Models/ICEvent.swift
@@ -139,6 +139,9 @@ public struct ICEvent: ICComponentable {
     /// https://www.rfc-editor.org/rfc/rfc5545#section-3.8.1.9)
     public var priority: Int?
 
+    /// Parsed event properties, including each property's parameters.
+    public var properties: [ICProperty]?
+
     /// This property is used in conjunction with the `UID` and `SEQUENCE` properties
     /// to identify a specific instance of a recurring `VEVENT`, `VTODO`, or `VJOURNAL`
     /// calendar component. The property value is the original value of the `DTSTART` property
@@ -224,6 +227,7 @@ public struct ICEvent: ICComponentable {
         nonStandardProperties: [String: String]? = nil,
         organizer: String? = nil,
         priority: Int? = nil,
+        properties: [ICProperty]? = nil,
         recurrenceDates: [ICDateTime]? = nil,
         recurrenceId: ICDateTime? = nil,
         resources: [String]? = nil,
@@ -251,6 +255,7 @@ public struct ICEvent: ICComponentable {
         self.nonStandardProperties = nonStandardProperties
         self.organizer = organizer
         self.priority = priority
+        self.properties = properties
         self.recurrenceDates = recurrenceDates
         self.recurrenceId = recurrenceId
         self.resources = resources

--- a/Sources/iCalendarParser/Models/ICParameter.swift
+++ b/Sources/iCalendarParser/Models/ICParameter.swift
@@ -1,14 +1,14 @@
 import Foundation
 
-struct ICParameter: Equatable {
-    let name: String
-    let values: [String]
+public struct ICParameter: Equatable {
+    public let name: String
+    public let values: [String]
 
-    var value: String {
+    public var value: String {
         values.joined(separator: ",")
     }
 
-    init(
+    public init(
         name: String,
         values: [String]
     ) {

--- a/Sources/iCalendarParser/Models/ICProperty.swift
+++ b/Sources/iCalendarParser/Models/ICProperty.swift
@@ -1,15 +1,15 @@
 import Foundation
 
-struct ICProperty: Equatable {
-    let name: String
-    let value: String
-    let parameters: [ICParameter]
+public struct ICProperty: Equatable {
+    public let name: String
+    public let value: String
+    public let parameters: [ICParameter]
 
-    var baseName: String {
+    public var baseName: String {
         name.split(separator: ";", maxSplits: 1).first.map(String.init) ?? name
     }
 
-    init(
+    public init(
         _ name: String,
         _ value: String
     ) {

--- a/Sources/iCalendarParser/Parser/ICParser.swift
+++ b/Sources/iCalendarParser/Parser/ICParser.swift
@@ -166,6 +166,7 @@ public struct ICParser {
             event.location = component.buildProperty(of: Constant.Property.location)
             event.organizer = component.buildProperty(of: Constant.Property.organizer)
             event.priority = component.buildProperty(of: Constant.Property.priority)
+            event.properties = component.contentProperties
             event.recurrenceDates = component.buildDateTimes(of: Constant.Property.recurrenceDates)
             event.recurrenceId = component.buildProperty(of: Constant.Property.recurrenceId)
             event.resources = component.buildCategories(of: Constant.Property.resources)

--- a/Tests/iCalendarParserTests/AttendeesTests.swift
+++ b/Tests/iCalendarParserTests/AttendeesTests.swift
@@ -88,4 +88,24 @@ final class AttendeesTests: XCTestCase {
 
         XCTAssertEqual(partstat, .accepted)
     }
+
+    func testAttendeeExposesRoleRsvpAndParameters() throws {
+        let propertyName = """
+        ATTENDEE;CUTYPE=INDIVIDUAL;ROLE=REQ-PARTICIPANT;PARTSTAT=ACCEPTED;\
+        RSVP=TRUE;CN=test@example.com;X-NUM-GUESTS=0
+        """
+        let property = ICProperty(
+            propertyName,
+            "mailto:test@example.com"
+        )
+
+        let attendee = try XCTUnwrap(PropertyBuilder.buildAttendees(from: [property])?.first)
+
+        XCTAssertEqual(attendee.cname, "test@example.com")
+        XCTAssertEqual(attendee.participationStatus, .accepted)
+        XCTAssertEqual(attendee.role, "REQ-PARTICIPANT")
+        XCTAssertEqual(attendee.rsvp, true)
+        XCTAssertEqual(attendee.parameters?.first(where: { $0.name == "ROLE" })?.value, "REQ-PARTICIPANT")
+        XCTAssertEqual(attendee.parameters?.first(where: { $0.name == "RSVP" })?.value, "TRUE")
+    }
 }

--- a/Tests/iCalendarParserTests/ICParserTests.swift
+++ b/Tests/iCalendarParserTests/ICParserTests.swift
@@ -148,4 +148,40 @@ final class ICParserTests: XCTestCase {
         XCTAssertEqual(duration.minutes, 30)
         XCTAssertNil(duration.seconds)
     }
+
+    func testEventExposesPropertyParameters() throws {
+        let iCalString = """
+        BEGIN:VCALENDAR\r
+        VERSION:2.0\r
+        PRODID:-//Example Inc//Calendar//EN\r
+        BEGIN:VEVENT\r
+        UID:property-parameters-test\r
+        DTSTAMP:20240728T120000Z\r
+        DTSTART;TZID=Europe/Paris:20240801T120000\r
+        DTEND;VALUE=DATE:20240802\r
+        SUMMARY;LANGUAGE=en;ALTREP="https://example.com/event":Board meeting\r
+        ATTENDEE;CN="Doe, John";ROLE=REQ-PARTICIPANT;PARTSTAT=ACCEPTED;RSVP=TRUE:mailto:john@example.com\r
+        END:VEVENT\r
+        END:VCALENDAR
+        """
+
+        let calendar = try XCTUnwrap(sut.calendar(from: iCalString))
+        let event = try XCTUnwrap(calendar.events.first)
+        let properties = try XCTUnwrap(event.properties)
+        let summary = try XCTUnwrap(properties.first(where: { $0.baseName == "SUMMARY" }))
+        let dtStart = try XCTUnwrap(properties.first(where: { $0.baseName == "DTSTART" }))
+        let dtEnd = try XCTUnwrap(properties.first(where: { $0.baseName == "DTEND" }))
+        let attendee = try XCTUnwrap(event.attendees?.first)
+
+        XCTAssertEqual(summary.parameters.first(where: { $0.name == "LANGUAGE" })?.value, "en")
+        XCTAssertEqual(summary.parameters.first(where: { $0.name == "ALTREP" })?.value, "https://example.com/event")
+        XCTAssertEqual(dtStart.parameters.first(where: { $0.name == "TZID" })?.value, "Europe/Paris")
+        XCTAssertEqual(dtEnd.parameters.first(where: { $0.name == "VALUE" })?.value, "DATE")
+        XCTAssertEqual(event.dtStart?.tzId, "Europe/Paris")
+        XCTAssertEqual(event.dtEnd?.type, .date)
+        XCTAssertEqual(attendee.cname, "Doe, John")
+        XCTAssertEqual(attendee.role, "REQ-PARTICIPANT")
+        XCTAssertEqual(attendee.participationStatus, .accepted)
+        XCTAssertEqual(attendee.rsvp, true)
+    }
 }


### PR DESCRIPTION
## Summary
- make parsed property and parameter models public
- expose parsed event properties with parameters through ICEvent
- expose ATTENDEE parameters plus typed ROLE and RSVP accessors
- update the README property-parameters roadmap item

## Validation
- swift test
- swiftlint lint --quiet