### PR TITLE
feat: expose event attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ iCalendarParser is currently not feature complete yet. While it requires an addi
   - [x] Add `COMMENT`, `CONTACT`, and `RESOURCES`
   - [x] Add `EXDATE` and `RDATE`
   - [x] Add `DURATION`
-  - [ ] Add `ATTACH`
+  - [x] Add `ATTACH`
   - [ ] Add `GEO`
   - [ ] Add `RELATED-TO`
   - [ ] Add `REQUEST-STATUS`

--- a/Sources/iCalendarParser/Builder/PropertyBuilder.swift
+++ b/Sources/iCalendarParser/Builder/PropertyBuilder.swift
@@ -119,6 +119,20 @@ struct PropertyBuilder {
         }
     }
 
+    static func buildAttachments(
+        from props: [ICProperty]
+    ) -> [ICAttachment] {
+        props.map { prop in
+            ICAttachment(
+                formatType: prop.parameters.first {
+                    $0.name == Constant.Property.formatType
+                }?.value,
+                url: URL(string: prop.value),
+                value: prop.value
+            )
+        }
+    }
+
     static func buildCategories(
         from props: [ICProperty]
     ) -> [String] {

--- a/Sources/iCalendarParser/Constant/Constant.swift
+++ b/Sources/iCalendarParser/Constant/Constant.swift
@@ -65,6 +65,7 @@ extension Constant {
         static let cname = "CN"
 
         static let attachment: String = "ATTACH"
+        static let formatType: String = "FMTTYPE"
         static let categories: String = "CATEGORIES"
         static let comment: String = "COMMENT"
         static let contact: String = "CONTACT"

--- a/Sources/iCalendarParser/Models/ICAttachment.swift
+++ b/Sources/iCalendarParser/Models/ICAttachment.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// Provides the capability to associate a document object with a calendar component.
+///
+/// See more in [RFC 5545](
+/// https://www.rfc-editor.org/rfc/rfc5545#section-3.8.1.1)
+public struct ICAttachment: Equatable {
+    public var formatType: String?
+    public var url: URL?
+    public var value: String
+
+    public init(
+        formatType: String? = nil,
+        url: URL? = nil,
+        value: String
+    ) {
+        self.formatType = formatType
+        self.url = url
+        self.value = value
+    }
+}

--- a/Sources/iCalendarParser/Models/ICComponent.swift
+++ b/Sources/iCalendarParser/Models/ICComponent.swift
@@ -89,6 +89,17 @@ struct ICComponent {
         return PropertyBuilder.buildAttendees(from: props)
     }
 
+    /// Returns `[ICAttachment]` from properties
+    func buildAttachments(
+        of name: String
+    ) -> [ICAttachment]? {
+        guard let props = getProperties(name: name), !props.isEmpty else {
+            return nil
+        }
+
+        return PropertyBuilder.buildAttachments(from: props)
+    }
+
     /// Returns category TEXT values from all matching properties.
     func buildCategories(
         of name: String

--- a/Sources/iCalendarParser/Models/ICEvent.swift
+++ b/Sources/iCalendarParser/Models/ICEvent.swift
@@ -17,11 +17,11 @@ public struct ICEvent: ICComponentable {
     /// https://www.rfc-editor.org/rfc/rfc5545#section-3.8.4.1)
     public var attendees: [ICAttendee]?
 
-    // Provides the capability to associate a document object with a calendar component.
-    //
-    // See more in [RFC 5545](
-    // https://www.rfc-editor.org/rfc/rfc5545#section-3.8.1.1))
-    // var attachment: [ICAttachment]?
+    /// Provides the capability to associate a document object with a calendar component.
+    ///
+    /// See more in [RFC 5545](
+    /// https://www.rfc-editor.org/rfc/rfc5545#section-3.8.1.1)
+    public var attachments: [ICAttachment]?
 
      public var categories: [String]?
 
@@ -208,6 +208,7 @@ public struct ICEvent: ICComponentable {
 
     public init(
         attendees: [ICAttendee]? = nil,
+        attachments: [ICAttachment]? = nil,
         categories: [String]? = nil,
         classification: String? = nil,
         comments: [String]? = nil,
@@ -235,6 +236,7 @@ public struct ICEvent: ICComponentable {
         url: URL? = nil
     ) {
         self.attendees = attendees
+        self.attachments = attachments
         self.categories = categories
         self.classification = classification
         self.comments = comments

--- a/Sources/iCalendarParser/Parser/ICParser.swift
+++ b/Sources/iCalendarParser/Parser/ICParser.swift
@@ -151,6 +151,7 @@ public struct ICParser {
             var event = ICEvent()
 
             event.attendees = component.buildAttendees(of: Constant.Property.attendee)
+            event.attachments = component.buildAttachments(of: Constant.Property.attachment)
             event.categories = component.buildCategories(of: Constant.Property.categories)
             event.classification = component.buildProperty(of: Constant.Property.classification)
             event.comments = component.buildCategories(of: Constant.Property.comment)

--- a/Tests/iCalendarParserTests/ICParserTests.swift
+++ b/Tests/iCalendarParserTests/ICParserTests.swift
@@ -148,4 +148,29 @@ final class ICParserTests: XCTestCase {
         XCTAssertEqual(duration.minutes, 30)
         XCTAssertNil(duration.seconds)
     }
+
+    func testEventAttachments() throws {
+        let iCalString = """
+        BEGIN:VCALENDAR\r
+        VERSION:2.0\r
+        PRODID:-//Example Inc//Calendar//EN\r
+        BEGIN:VEVENT\r
+        UID:attachment-test\r
+        DTSTAMP:20240728T120000Z\r
+        ATTACH;FMTTYPE=application/pdf:https://example.com/agenda.pdf\r
+        ATTACH:https://example.com/notes.txt\r
+        END:VEVENT\r
+        END:VCALENDAR
+        """
+
+        let calendar = try XCTUnwrap(sut.calendar(from: iCalString))
+        let event = try XCTUnwrap(calendar.events.first)
+        let attachments = try XCTUnwrap(event.attachments)
+
+        XCTAssertEqual(attachments.count, 2)
+        XCTAssertEqual(attachments[0].formatType, "application/pdf")
+        XCTAssertEqual(attachments[0].url?.absoluteString, "https://example.com/agenda.pdf")
+        XCTAssertEqual(attachments[0].value, "https://example.com/agenda.pdf")
+        XCTAssertEqual(attachments[1].url?.absoluteString, "https://example.com/notes.txt")
+    }
 }


### PR DESCRIPTION
## Summary
- add ICAttachment for VEVENT ATTACH properties
- parse repeated ATTACH values and FMTTYPE parameters
- expose attachments through ICEvent
- update the README event-property checklist

## Validation
- swift test
- swiftlint lint --quiet