### PR TITLE
feat: parse period values

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ iCalendarParser is currently not feature complete yet. While it requires an addi
   - [x] Parse `DATE`
   - [x] Parse `DATE-TIME`
   - [ ] Parse `DURATION`
-  - [ ] Parse `PERIOD`
+  - [x] Parse `PERIOD`
   - [ ] Parse `URI`
   - [ ] Parse `UTC-OFFSET`
 - [ ] Serialization

--- a/Sources/iCalendarParser/Builder/PropertyBuilder.swift
+++ b/Sources/iCalendarParser/Builder/PropertyBuilder.swift
@@ -42,6 +42,29 @@ struct PropertyBuilder {
         ICDuration(rawValue: prop.value)
     }
 
+    static func buildPeriod(
+        from prop: ICProperty
+    ) -> ICPeriod? {
+        let components = ICProperty.split(prop.value, separator: "/", maxSplits: 1)
+
+        guard
+            components.count == 2,
+            let start = buildDateTime(from: ICProperty(prop.name, components[0]))
+        else {
+            return nil
+        }
+
+        if let duration = ICDuration(rawValue: components[1]) {
+            return ICPeriod(duration: duration, rawValue: prop.value, start: start)
+        }
+
+        guard let end = buildDateTime(from: ICProperty(prop.name, components[1])) else {
+            return nil
+        }
+
+        return ICPeriod(end: end, rawValue: prop.value, start: start)
+    }
+
     // swiftlint:disable:next cyclomatic_complexity
     static func buildRRule(
         from prop: ICProperty

--- a/Sources/iCalendarParser/Models/ICPeriod.swift
+++ b/Sources/iCalendarParser/Models/ICPeriod.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// A period of time identified by a start and an end or duration.
+///
+/// See more in [RFC 5545](
+/// https://www.rfc-editor.org/rfc/rfc5545#section-3.3.9)
+public struct ICPeriod: Equatable {
+    public var duration: ICDuration?
+    public var end: ICDateTime?
+    public var rawValue: String
+    public var start: ICDateTime
+
+    public init(
+        duration: ICDuration? = nil,
+        end: ICDateTime? = nil,
+        rawValue: String,
+        start: ICDateTime
+    ) {
+        self.duration = duration
+        self.end = end
+        self.rawValue = rawValue
+        self.start = start
+    }
+}

--- a/Tests/iCalendarParserTests/PeriodTests.swift
+++ b/Tests/iCalendarParserTests/PeriodTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import iCalendarParser
+
+final class PeriodTests: XCTestCase {
+    func testBuildPeriodWithExplicitEnd() throws {
+        let period = try XCTUnwrap(
+            PropertyBuilder.buildPeriod(
+                from: ICProperty("FREEBUSY", "20240801T120000Z/20240801T130000Z")
+            )
+        )
+
+        XCTAssertNil(period.duration)
+        XCTAssertNotNil(period.end)
+        XCTAssertEqual(period.rawValue, "20240801T120000Z/20240801T130000Z")
+        XCTAssertEqual(
+            period.start.type.dateFormatter(tzId: period.start.tzId).string(from: period.start.date),
+            "20240801T120000Z"
+        )
+        XCTAssertEqual(
+            period.end?.type.dateFormatter(tzId: period.end?.tzId).string(from: try XCTUnwrap(period.end?.date)),
+            "20240801T130000Z"
+        )
+    }
+
+    func testBuildPeriodWithDuration() throws {
+        let period = try XCTUnwrap(
+            PropertyBuilder.buildPeriod(
+                from: ICProperty("FREEBUSY", "20240801T120000Z/PT1H30M")
+            )
+        )
+
+        XCTAssertNil(period.end)
+        XCTAssertEqual(period.duration?.hours, 1)
+        XCTAssertEqual(period.duration?.minutes, 30)
+        XCTAssertEqual(period.rawValue, "20240801T120000Z/PT1H30M")
+    }
+
+    func testInvalidPeriodReturnsNil() {
+        XCTAssertNil(PropertyBuilder.buildPeriod(from: ICProperty("FREEBUSY", "20240801T120000Z")))
+        XCTAssertNil(PropertyBuilder.buildPeriod(from: ICProperty("FREEBUSY", "invalid/PT1H")))
+        XCTAssertNil(PropertyBuilder.buildPeriod(from: ICProperty("FREEBUSY", "20240801T120000Z/invalid")))
+    }
+}


### PR DESCRIPTION
## Summary
- add ICPeriod for RFC 5545 PERIOD values
- parse explicit start/end periods
- parse start/duration periods
- update the README value-type checklist

## Validation
- swift test
- swiftlint lint --quiet