### PR TITLE
feat: fold long content lines

### DIFF
--- a/Sources/iCalendarParser/Formatter/ICFormatter.swift
+++ b/Sources/iCalendarParser/Formatter/ICFormatter.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 struct ICFormatter {
+    static let maxLineLength = 75
+    private static let continuationPrefix = " "
 
     /// Returns a configured `DateFormatter` based on `ICDateTimeType`
     static func dateFormatter(
@@ -29,5 +31,51 @@ struct ICFormatter {
         }()
 
         return formatter
+    }
+
+    /// Folds an iCalendar content line to the RFC 5545 line length limit.
+    ///
+    /// Continuation lines begin with a single space.
+    static func foldLine(
+        _ line: String
+    ) -> String {
+        guard line.utf8.count > maxLineLength else {
+            return line
+        }
+
+        var lines = [String]()
+        var currentLine = ""
+        var currentLineLength = 0
+        var currentLimit = maxLineLength
+
+        for character in line {
+            let characterLength = String(character).utf8.count
+
+            if !currentLine.isEmpty,
+               currentLineLength + characterLength > currentLimit {
+                lines.append(currentLine)
+                currentLine = String(character)
+                currentLineLength = characterLength
+                currentLimit = maxLineLength - continuationPrefix.utf8.count
+            } else {
+                currentLine.append(character)
+                currentLineLength += characterLength
+            }
+        }
+
+        lines.append(currentLine)
+
+        return lines
+            .enumerated()
+            .map { index, line in
+                index == 0 ? line : continuationPrefix + line
+            }
+            .joined(separator: "\r\n")
+    }
+
+    static func foldLines(
+        _ lines: [String]
+    ) -> String {
+        lines.map(foldLine).joined(separator: "\r\n")
     }
 }

--- a/Tests/iCalendarParserTests/FormatterTests.swift
+++ b/Tests/iCalendarParserTests/FormatterTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import iCalendarParser
+
+final class FormatterTests: XCTestCase {
+    func testFoldLineKeepsShortLineUnchanged() {
+        let line = "SUMMARY:Board meeting"
+
+        XCTAssertEqual(ICFormatter.foldLine(line), line)
+    }
+
+    func testFoldLineWrapsLongLineWithContinuationSpace() {
+        let line = "SUMMARY:" + String(repeating: "A", count: 80)
+        let folded = ICFormatter.foldLine(line)
+        let lines = folded.components(separatedBy: "\r\n")
+
+        XCTAssertEqual(lines.count, 2)
+        XCTAssertEqual(lines[0].utf8.count, 75)
+        XCTAssertEqual(lines[1].first, " ")
+        XCTAssertEqual(lines[1].utf8.count, 14)
+        XCTAssertEqual(folded.replacingOccurrences(of: "\r\n ", with: ""), line)
+    }
+
+    func testFoldLineCountsUtf8Octets() {
+        let line = "SUMMARY:" + String(repeating: "é", count: 40)
+        let folded = ICFormatter.foldLine(line)
+        let lines = folded.components(separatedBy: "\r\n")
+
+        XCTAssertEqual(lines.count, 2)
+        XCTAssertLessThanOrEqual(lines[0].utf8.count, 75)
+        XCTAssertLessThanOrEqual(lines[1].utf8.count, 75)
+        XCTAssertEqual(lines[1].first, " ")
+        XCTAssertEqual(folded.replacingOccurrences(of: "\r\n ", with: ""), line)
+    }
+
+    func testFoldLinesFoldsEachLine() {
+        let lines = [
+            "SUMMARY:Short",
+            "DESCRIPTION:" + String(repeating: "A", count: 80)
+        ]
+
+        let folded = ICFormatter.foldLines(lines)
+
+        XCTAssertTrue(folded.contains("SUMMARY:Short\r\nDESCRIPTION:"))
+        XCTAssertTrue(folded.contains("\r\n "))
+    }
+}


### PR DESCRIPTION
## Summary
- add formatter helpers for folding iCalendar content lines
- enforce the RFC 5545 75-octet line limit using UTF-8 byte counts
- preserve valid Swift character boundaries while folding

## Validation
- swift test
- swiftlint lint --quiet