### PR TITLE
feat: parse utc offset values

### DIFF
--- a/Sources/iCalendarParser/Builder/PropertyBuilder.swift
+++ b/Sources/iCalendarParser/Builder/PropertyBuilder.swift
@@ -81,6 +81,12 @@ struct PropertyBuilder {
         return ICPeriod(end: end, rawValue: prop.value, start: start)
     }
 
+    static func buildUtcOffset(
+        from prop: ICProperty
+    ) -> ICUtcOffset? {
+        ICUtcOffset(rawValue: prop.value)
+    }
+
     // swiftlint:disable:next cyclomatic_complexity
     static func buildRRule(
         from prop: ICProperty

--- a/Sources/iCalendarParser/Models/ICUtcOffset.swift
+++ b/Sources/iCalendarParser/Models/ICUtcOffset.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+/// A signed offset from UTC.
+///
+/// See more in [RFC 5545](
+/// https://www.rfc-editor.org/rfc/rfc5545#section-3.3.14)
+public struct ICUtcOffset: Equatable {
+    public var hours: Int
+    public var isNegative: Bool
+    public var minutes: Int
+    public var rawValue: String
+    public var seconds: Int?
+
+    public var totalSeconds: Int {
+        let total = hours * 3_600 + minutes * 60 + (seconds ?? 0)
+        return isNegative ? -total : total
+    }
+
+    public init(
+        hours: Int,
+        isNegative: Bool = false,
+        minutes: Int,
+        rawValue: String,
+        seconds: Int? = nil
+    ) {
+        self.hours = hours
+        self.isNegative = isNegative
+        self.minutes = minutes
+        self.rawValue = rawValue
+        self.seconds = seconds
+    }
+
+    public init?(
+        rawValue: String
+    ) {
+        guard
+            rawValue.count == 5 || rawValue.count == 7,
+            let sign = rawValue.first,
+            sign == "+" || sign == "-"
+        else {
+            return nil
+        }
+
+        let digits = rawValue.dropFirst()
+
+        guard digits.allSatisfy(\.isNumber) else {
+            return nil
+        }
+
+        let hourEnd = digits.index(digits.startIndex, offsetBy: 2)
+        let minuteEnd = digits.index(hourEnd, offsetBy: 2)
+
+        guard
+            let hours = Int(digits[..<hourEnd]),
+            let minutes = Int(digits[hourEnd..<minuteEnd]),
+            (0...23).contains(hours),
+            (0...59).contains(minutes)
+        else {
+            return nil
+        }
+
+        var seconds: Int?
+
+        if rawValue.count == 7 {
+            guard
+                let parsedSeconds = Int(digits[minuteEnd...]),
+                (0...59).contains(parsedSeconds)
+            else {
+                return nil
+            }
+
+            seconds = parsedSeconds
+        }
+
+        self.init(
+            hours: hours,
+            isNegative: sign == "-",
+            minutes: minutes,
+            rawValue: rawValue,
+            seconds: seconds
+        )
+    }
+}

--- a/Tests/iCalendarParserTests/UtcOffsetTests.swift
+++ b/Tests/iCalendarParserTests/UtcOffsetTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import iCalendarParser
+
+final class UtcOffsetTests: XCTestCase {
+    func testBuildPositiveUtcOffset() throws {
+        let offset = try XCTUnwrap(
+            PropertyBuilder.buildUtcOffset(from: ICProperty("TZOFFSETTO", "+0530"))
+        )
+
+        XCTAssertFalse(offset.isNegative)
+        XCTAssertEqual(offset.hours, 5)
+        XCTAssertEqual(offset.minutes, 30)
+        XCTAssertNil(offset.seconds)
+        XCTAssertEqual(offset.totalSeconds, 19_800)
+        XCTAssertEqual(offset.rawValue, "+0530")
+    }
+
+    func testBuildNegativeUtcOffsetWithSeconds() throws {
+        let offset = try XCTUnwrap(
+            PropertyBuilder.buildUtcOffset(from: ICProperty("TZOFFSETFROM", "-033045"))
+        )
+
+        XCTAssertTrue(offset.isNegative)
+        XCTAssertEqual(offset.hours, 3)
+        XCTAssertEqual(offset.minutes, 30)
+        XCTAssertEqual(offset.seconds, 45)
+        XCTAssertEqual(offset.totalSeconds, -12_645)
+    }
+
+    func testInvalidUtcOffsetReturnsNil() {
+        XCTAssertNil(PropertyBuilder.buildUtcOffset(from: ICProperty("TZOFFSETTO", "0530")))
+        XCTAssertNil(PropertyBuilder.buildUtcOffset(from: ICProperty("TZOFFSETTO", "+2460")))
+        XCTAssertNil(PropertyBuilder.buildUtcOffset(from: ICProperty("TZOFFSETTO", "+053060")))
+        XCTAssertNil(PropertyBuilder.buildUtcOffset(from: ICProperty("TZOFFSETTO", "+05:30")))
+    }
+}


### PR DESCRIPTION
## Summary
- add ICUtcOffset for RFC 5545 UTC-OFFSET values
- parse signed HHMM and HHMMSS offsets
- expose total seconds for easier offset use

## Validation
- swift test
- swiftlint lint --quiet