### PR TITLE
feat: add validation rules

### DIFF
--- a/Sources/iCalendarParser/Validation/ICValidationError.swift
+++ b/Sources/iCalendarParser/Validation/ICValidationError.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+public enum ICValidationError: Equatable {
+    case missingProductIdentifier
+    case missingEventDateStamp(uid: String)
+    case missingEventUID
+    case mutuallyExclusiveEventDateEndAndDuration(uid: String)
+}

--- a/Sources/iCalendarParser/Validation/ICValidator.swift
+++ b/Sources/iCalendarParser/Validation/ICValidator.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+public struct ICValidator {
+    public init() {}
+
+    public func validate(
+        _ calendar: ICalendar
+    ) -> [ICValidationError] {
+        var errors = [ICValidationError]()
+
+        if calendar.productId.parameters.isEmpty {
+            errors.append(.missingProductIdentifier)
+        }
+
+        calendar.events.forEach { event in
+            errors.append(contentsOf: validate(event))
+        }
+
+        return errors
+    }
+
+    public func validate(
+        _ event: ICEvent
+    ) -> [ICValidationError] {
+        var errors = [ICValidationError]()
+
+        if isMissingProperty(Constant.Property.uid, in: event) || event.uid.isEmpty {
+            errors.append(.missingEventUID)
+        }
+
+        if isMissingProperty(Constant.Property.dtStamp, in: event) {
+            errors.append(.missingEventDateStamp(uid: event.uid))
+        }
+
+        if event.dtEnd != nil, event.duration != nil {
+            errors.append(.mutuallyExclusiveEventDateEndAndDuration(uid: event.uid))
+        }
+
+        return errors
+    }
+
+    private func isMissingProperty(
+        _ name: String,
+        in event: ICEvent
+    ) -> Bool {
+        guard let properties = event.properties else {
+            return false
+        }
+
+        return !properties.contains { $0.baseName == name }
+    }
+}

--- a/Tests/iCalendarParserTests/ValidationTests.swift
+++ b/Tests/iCalendarParserTests/ValidationTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+@testable import iCalendarParser
+
+final class ValidationTests: XCTestCase {
+    func testCalendarValidationRequiresProductIdentifier() {
+        let calendar = ICalendar(productId: ICProductIdentifier(""))
+
+        let errors = ICValidator().validate(calendar)
+
+        XCTAssertEqual(errors, [.missingProductIdentifier])
+    }
+
+    func testEventValidationRequiresUIDWhenParsedPropertiesAreAvailable() throws {
+        let calendar = try XCTUnwrap(ICParser().calendar(from: """
+        BEGIN:VCALENDAR\r
+        VERSION:2.0\r
+        PRODID:-//Example Inc//Calendar//EN\r
+        BEGIN:VEVENT\r
+        DTSTAMP:20240728T120000Z\r
+        END:VEVENT\r
+        END:VCALENDAR
+        """))
+
+        let errors = ICValidator().validate(calendar)
+
+        XCTAssertEqual(errors, [.missingEventUID])
+    }
+
+    func testEventValidationRequiresDateStampWhenParsedPropertiesAreAvailable() throws {
+        let calendar = try XCTUnwrap(ICParser().calendar(from: """
+        BEGIN:VCALENDAR\r
+        VERSION:2.0\r
+        PRODID:-//Example Inc//Calendar//EN\r
+        BEGIN:VEVENT\r
+        UID:missing-dtstamp-test\r
+        END:VEVENT\r
+        END:VCALENDAR
+        """))
+
+        let errors = ICValidator().validate(calendar)
+
+        XCTAssertEqual(errors, [.missingEventDateStamp(uid: "missing-dtstamp-test")])
+    }
+
+    func testEventValidationRejectsDateEndAndDurationTogether() {
+        let event = ICEvent(
+            dtEnd: .dateTime(from: Date(timeIntervalSince1970: 3_600)),
+            duration: ICDuration(rawValue: "PT1H"),
+            uid: "mutually-exclusive-test"
+        )
+
+        let errors = ICValidator().validate(event)
+
+        XCTAssertEqual(
+            errors,
+            [.mutuallyExclusiveEventDateEndAndDuration(uid: "mutually-exclusive-test")]
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- add ICValidator for standalone calendar and event validation
- report missing product identifiers and parsed event UID/DTSTAMP properties
- report mutually exclusive DTEND and DURATION on events

## Validation
- swift test
- swiftlint lint --quiet