### PR TITLE
feat: expose event related-to properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ iCalendarParser is currently not feature complete yet. While it requires an addi
   - [x] Add `DURATION`
   - [x] Add `ATTACH`
   - [x] Add `GEO`
-  - [ ] Add `RELATED-TO`
+  - [x] Add `RELATED-TO`
   - [ ] Add `REQUEST-STATUS`
 - [ ] Recurrence
   - [x] Parse basic `RRULE`

--- a/Sources/iCalendarParser/Constant/Constant.swift
+++ b/Sources/iCalendarParser/Constant/Constant.swift
@@ -82,6 +82,7 @@ extension Constant {
         static let location: String = "LOCATION"
         static let organizer: String = "ORGANIZER"
         static let priority: String = "PRIORITY"
+        static let relatedTo: String = "RELATED-TO"
         static let recurrenceDates: String = "RDATE"
         static let recurrenceId: String = "RECURRENCE-ID"
         static let recurrenceRule: String = "RRULE"

--- a/Sources/iCalendarParser/Models/ICEvent.swift
+++ b/Sources/iCalendarParser/Models/ICEvent.swift
@@ -163,7 +163,12 @@ public struct ICEvent: ICComponentable {
     // https://www.rfc-editor.org/rfc/rfc5545#section-3.8.5.3)
     public var recurrenceRule: ICRRule?
 
-    // var relatedTo: [String]?
+    /// Represents a relationship or reference between one calendar component
+    /// and another.
+    ///
+    /// See more in [RFC 5545](
+    /// https://www.rfc-editor.org/rfc/rfc5545#section-3.8.4.5)
+    public var relatedTo: [String]?
 
     // var requestStatus
 
@@ -230,6 +235,7 @@ public struct ICEvent: ICComponentable {
         organizer: String? = nil,
         priority: Int? = nil,
         properties: [ICProperty]? = nil,
+        relatedTo: [String]? = nil,
         recurrenceDates: [ICDateTime]? = nil,
         recurrenceId: ICDateTime? = nil,
         resources: [String]? = nil,
@@ -260,6 +266,7 @@ public struct ICEvent: ICComponentable {
         self.organizer = organizer
         self.priority = priority
         self.properties = properties
+        self.relatedTo = relatedTo
         self.recurrenceDates = recurrenceDates
         self.recurrenceId = recurrenceId
         self.resources = resources

--- a/Sources/iCalendarParser/Parser/ICParser.swift
+++ b/Sources/iCalendarParser/Parser/ICParser.swift
@@ -169,6 +169,7 @@ public struct ICParser {
             event.organizer = component.buildProperty(of: Constant.Property.organizer)
             event.priority = component.buildProperty(of: Constant.Property.priority)
             event.properties = component.contentProperties
+            event.relatedTo = component.buildCategories(of: Constant.Property.relatedTo)
             event.recurrenceDates = component.buildDateTimes(of: Constant.Property.recurrenceDates)
             event.recurrenceId = component.buildProperty(of: Constant.Property.recurrenceId)
             event.resources = component.buildCategories(of: Constant.Property.resources)

--- a/Tests/iCalendarParserTests/ICParserTests.swift
+++ b/Tests/iCalendarParserTests/ICParserTests.swift
@@ -206,6 +206,26 @@ final class ICParserTests: XCTestCase {
         XCTAssertEqual(geoPosition.longitude, -122.082932)
     }
 
+    func testEventRelatedToProperties() throws {
+        let iCalString = """
+        BEGIN:VCALENDAR\r
+        VERSION:2.0\r
+        PRODID:-//Example Inc//Calendar//EN\r
+        BEGIN:VEVENT\r
+        UID:child-event\r
+        DTSTAMP:20240728T120000Z\r
+        RELATED-TO:parent-event\r
+        RELATED-TO;RELTYPE=SIBLING:sibling-event\r
+        END:VEVENT\r
+        END:VCALENDAR
+        """
+
+        let calendar = try XCTUnwrap(sut.calendar(from: iCalString))
+        let event = try XCTUnwrap(calendar.events.first)
+
+        XCTAssertEqual(event.relatedTo, ["parent-event", "sibling-event"])
+    }
+
     func testEventAttachments() throws {
         let iCalString = """
         BEGIN:VCALENDAR\r


### PR DESCRIPTION
## Summary
- parse repeated VEVENT RELATED-TO properties
- expose related component UIDs through ICEvent.relatedTo
- update the README roadmap for RELATED-TO support

## Example ICS
```ics
BEGIN:VEVENT
UID:child-event
DTSTAMP:20240728T120000Z
RELATED-TO:parent-event
RELATED-TO;RELTYPE=SIBLING:sibling-event
END:VEVENT
```

## What becomes available
Consumers can now read related event identifiers from parsed events:

```swift
event.relatedTo // ["parent-event", "sibling-event"]
```

## Validation
- swift test
- swiftlint lint --quiet