### PR TITLE
feat: expose event request status

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ iCalendarParser is currently not feature complete yet. While it requires an addi
   - [x] Add `ATTACH`
   - [x] Add `GEO`
   - [ ] Add `RELATED-TO`
-  - [ ] Add `REQUEST-STATUS`
+  - [x] Add `REQUEST-STATUS`
 - [ ] Recurrence
   - [x] Parse basic `RRULE`
   - [ ] Expand recurring events into instances

--- a/Sources/iCalendarParser/Constant/Constant.swift
+++ b/Sources/iCalendarParser/Constant/Constant.swift
@@ -85,6 +85,7 @@ extension Constant {
         static let recurrenceDates: String = "RDATE"
         static let recurrenceId: String = "RECURRENCE-ID"
         static let recurrenceRule: String = "RRULE"
+        static let requestStatus: String = "REQUEST-STATUS"
         static let resources: String = "RESOURCES"
         static let sequence: String = "SEQUENCE"
         static let status: String = "STATUS"

--- a/Sources/iCalendarParser/Models/ICComponent.swift
+++ b/Sources/iCalendarParser/Models/ICComponent.swift
@@ -141,6 +141,18 @@ struct ICComponent {
         return dateTimes.isEmpty ? nil : dateTimes
     }
 
+    /// Returns request-status values from all matching properties.
+    func buildRequestStatuses(
+        of name: String
+    ) -> [ICRequestStatus]? {
+        guard let props = getProperties(name: name), !props.isEmpty else {
+            return nil
+        }
+
+        let requestStatuses = props.compactMap { ICRequestStatus(rawValue: $0.value) }
+        return requestStatuses.isEmpty ? nil : requestStatuses
+    }
+
     /// Returns all non-standard properties if exists
     func getNonStandardProperties() -> [String: String]? {
         var dict = [String: String]()

--- a/Sources/iCalendarParser/Models/ICEvent.swift
+++ b/Sources/iCalendarParser/Models/ICEvent.swift
@@ -165,7 +165,11 @@ public struct ICEvent: ICComponentable {
 
     // var relatedTo: [String]?
 
-    // var requestStatus
+    /// Defines the status code returned for a scheduling request.
+    ///
+    /// See more in [RFC 5545](
+    /// https://www.rfc-editor.org/rfc/rfc5545#section-3.8.8.3)
+    public var requestStatuses: [ICRequestStatus]?
 
     /// Defines the equipment or resources anticipated for an activity specified by a calendar component.
     ///
@@ -232,6 +236,7 @@ public struct ICEvent: ICComponentable {
         properties: [ICProperty]? = nil,
         recurrenceDates: [ICDateTime]? = nil,
         recurrenceId: ICDateTime? = nil,
+        requestStatuses: [ICRequestStatus]? = nil,
         resources: [String]? = nil,
         sequence: Int? = nil,
         status: String? = nil,
@@ -262,6 +267,7 @@ public struct ICEvent: ICComponentable {
         self.properties = properties
         self.recurrenceDates = recurrenceDates
         self.recurrenceId = recurrenceId
+        self.requestStatuses = requestStatuses
         self.resources = resources
         self.sequence = sequence
         self.status = status

--- a/Sources/iCalendarParser/Models/ICRequestStatus.swift
+++ b/Sources/iCalendarParser/Models/ICRequestStatus.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Defines the status code returned for a scheduling request.
+///
+/// See more in [RFC 5545](
+/// https://www.rfc-editor.org/rfc/rfc5545#section-3.8.8.3)
+public struct ICRequestStatus: Equatable {
+    public var code: String
+    public var description: String
+    public var exceptionData: String?
+    public var rawValue: String
+
+    public init(
+        code: String,
+        description: String,
+        exceptionData: String? = nil,
+        rawValue: String
+    ) {
+        self.code = code
+        self.description = description
+        self.exceptionData = exceptionData
+        self.rawValue = rawValue
+    }
+
+    public init?(
+        rawValue: String
+    ) {
+        let components = rawValue.components(separatedBy: ";")
+
+        guard components.count >= 2 else {
+            return nil
+        }
+
+        self.init(
+            code: components[0],
+            description: components[1],
+            exceptionData: components.dropFirst(2).isEmpty
+                ? nil
+                : components.dropFirst(2).joined(separator: ";"),
+            rawValue: rawValue
+        )
+    }
+}

--- a/Sources/iCalendarParser/Parser/ICParser.swift
+++ b/Sources/iCalendarParser/Parser/ICParser.swift
@@ -171,6 +171,7 @@ public struct ICParser {
             event.properties = component.contentProperties
             event.recurrenceDates = component.buildDateTimes(of: Constant.Property.recurrenceDates)
             event.recurrenceId = component.buildProperty(of: Constant.Property.recurrenceId)
+            event.requestStatuses = component.buildRequestStatuses(of: Constant.Property.requestStatus)
             event.resources = component.buildCategories(of: Constant.Property.resources)
             event.sequence = component.buildProperty(of: Constant.Property.sequence)
             event.status = component.buildProperty(of: Constant.Property.status)

--- a/Tests/iCalendarParserTests/ICParserTests.swift
+++ b/Tests/iCalendarParserTests/ICParserTests.swift
@@ -206,6 +206,33 @@ final class ICParserTests: XCTestCase {
         XCTAssertEqual(geoPosition.longitude, -122.082932)
     }
 
+    func testEventRequestStatusProperties() throws {
+        let iCalString = """
+        BEGIN:VCALENDAR\r
+        VERSION:2.0\r
+        PRODID:-//Example Inc//Calendar//EN\r
+        BEGIN:VEVENT\r
+        UID:request-status-test\r
+        DTSTAMP:20240728T120000Z\r
+        REQUEST-STATUS:2.0;Success\r
+        REQUEST-STATUS:3.7;Invalid calendar user;ATTENDEE\r
+        END:VEVENT\r
+        END:VCALENDAR
+        """
+
+        let calendar = try XCTUnwrap(sut.calendar(from: iCalString))
+        let event = try XCTUnwrap(calendar.events.first)
+        let requestStatuses = try XCTUnwrap(event.requestStatuses)
+
+        XCTAssertEqual(requestStatuses.count, 2)
+        XCTAssertEqual(requestStatuses[0].code, "2.0")
+        XCTAssertEqual(requestStatuses[0].description, "Success")
+        XCTAssertNil(requestStatuses[0].exceptionData)
+        XCTAssertEqual(requestStatuses[1].code, "3.7")
+        XCTAssertEqual(requestStatuses[1].description, "Invalid calendar user")
+        XCTAssertEqual(requestStatuses[1].exceptionData, "ATTENDEE")
+    }
+
     func testEventAttachments() throws {
         let iCalString = """
         BEGIN:VCALENDAR\r


### PR DESCRIPTION
## Summary
- add ICRequestStatus for VEVENT REQUEST-STATUS values
- parse repeated REQUEST-STATUS properties into ICEvent.requestStatuses
- update the README roadmap for REQUEST-STATUS support

## Example ICS
```ics
BEGIN:VEVENT
UID:request-status-test
DTSTAMP:20240728T120000Z
REQUEST-STATUS:2.0;Success
REQUEST-STATUS:3.7;Invalid calendar user;ATTENDEE
END:VEVENT
```

## What becomes available
Consumers can now inspect scheduling request status values from parsed events:

```swift
event.requestStatuses?.first?.code // "2.0"
event.requestStatuses?.first?.description // "Success"
event.requestStatuses?[1].exceptionData // "ATTENDEE"
```

## Validation
- swift test
- swiftlint lint --quiet