### PR TITLE
feat: parse uri values

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ iCalendarParser is currently not feature complete yet. While it requires an addi
   - [x] Parse `DATE-TIME`
   - [ ] Parse `DURATION`
   - [x] Parse `PERIOD`
-  - [ ] Parse `URI`
+  - [x] Parse `URI`
   - [x] Parse `UTC-OFFSET`
 - [ ] Serialization
   - [ ] Format calendars back to valid `.ics`

--- a/Sources/iCalendarParser/Builder/PropertyBuilder.swift
+++ b/Sources/iCalendarParser/Builder/PropertyBuilder.swift
@@ -185,7 +185,7 @@ struct PropertyBuilder {
                 formatType: prop.parameters.first {
                     $0.name == Constant.Property.formatType
                 }?.value,
-                url: URL(string: prop.value),
+                url: ICURI(rawValue: prop.value)?.url,
                 value: prop.value
             )
         }

--- a/Sources/iCalendarParser/Models/ICComponent.swift
+++ b/Sources/iCalendarParser/Models/ICComponent.swift
@@ -96,6 +96,17 @@ struct ICComponent {
         return PropertyBuilder.buildGeoPosition(from: prop)
     }
 
+    /// Returns `URL` from URI properties
+    func buildURI(
+        of name: String
+    ) -> URL? {
+        guard let prop = getProperty(name: name) else {
+            return nil
+        }
+
+        return ICURI(rawValue: prop.value)?.url
+    }
+
     /// Returns `[Attendee]` from properties
     func buildAttendees(
         of name: String

--- a/Sources/iCalendarParser/Models/ICURI.swift
+++ b/Sources/iCalendarParser/Models/ICURI.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// A URI value.
+///
+/// See more in [RFC 5545](
+/// https://www.rfc-editor.org/rfc/rfc5545#section-3.3.13)
+public struct ICURI: Equatable {
+    public var rawValue: String
+    public var url: URL
+
+    public init?(
+        rawValue: String
+    ) {
+        guard
+            let url = URL(string: rawValue),
+            url.scheme != nil
+        else {
+            return nil
+        }
+
+        self.rawValue = rawValue
+        self.url = url
+    }
+}

--- a/Sources/iCalendarParser/Parser/ICParser.swift
+++ b/Sources/iCalendarParser/Parser/ICParser.swift
@@ -178,7 +178,7 @@ public struct ICParser {
             event.status = component.buildProperty(of: Constant.Property.status)
             event.summary = component.buildProperty(of: Constant.Property.summary)
             event.timeTransparency = component.buildProperty(of: Constant.Property.timeTransparency)
-            event.url = URL(string: component.buildProperty(of: Constant.Property.url) ?? "")
+            event.url = component.buildURI(of: Constant.Property.url)
             event.uid = component.buildProperty(of: Constant.Property.uid) ?? ""
             event.recurrenceRule = component.buildProperty(of: Constant.Property.recurrenceRule)
 

--- a/Tests/iCalendarParserTests/URITests.swift
+++ b/Tests/iCalendarParserTests/URITests.swift
@@ -1,0 +1,35 @@
+import XCTest
+@testable import iCalendarParser
+
+final class URITests: XCTestCase {
+
+    func testBuildURI() throws {
+        let uri = try XCTUnwrap(ICURI(rawValue: "https://example.com/events/1?source=calendar"))
+
+        XCTAssertEqual(uri.rawValue, "https://example.com/events/1?source=calendar")
+        XCTAssertEqual(uri.url.absoluteString, "https://example.com/events/1?source=calendar")
+    }
+
+    func testBuildURIRequiresScheme() {
+        XCTAssertNil(ICURI(rawValue: "example.com/events/1"))
+    }
+
+    func testParserBuildsEventURLFromURIValue() throws {
+        let ics = """
+        BEGIN:VCALENDAR\r
+        VERSION:2.0\r
+        PRODID:-//Test//iCalendarParser//EN\r
+        BEGIN:VEVENT\r
+        UID:uri-test\r
+        DTSTAMP:20240728T120000Z\r
+        URL:https://example.com/events/1?source=calendar\r
+        END:VEVENT\r
+        END:VCALENDAR\r
+        """
+
+        let calendar = try XCTUnwrap(ICParser().calendar(from: ics))
+        let event = try XCTUnwrap(calendar.events.first)
+
+        XCTAssertEqual(event.url?.absoluteString, "https://example.com/events/1?source=calendar")
+    }
+}


### PR DESCRIPTION
## Summary
- Add an `ICURI` value type for RFC 5545 URI values
- Use URI parsing for event `URL` and attachment URLs
- Mark `Parse URI` complete in the README roadmap

## Example ICS
```ics
BEGIN:VEVENT
UID:uri-test
DTSTAMP:20240728T120000Z
URL:https://example.com/events/1?source=calendar
ATTACH;FMTTYPE=application/pdf:https://example.com/files/agenda.pdf
END:VEVENT
```

## What becomes available
```swift
event.url?.absoluteString // "https://example.com/events/1?source=calendar"
event.attachments?.first?.url?.absoluteString // "https://example.com/files/agenda.pdf"
ICURI(rawValue: "https://example.com/events/1")?.url
```

URI values now require a scheme, so malformed values like `example.com/events/1` are not treated as valid URLs.

## Validation
- `swift test`
- `swiftlint lint --quiet`