### PR TITLE
feat: escape text values

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ iCalendarParser is currently not feature complete yet. While it requires an addi
 - [ ] Serialization
   - [ ] Format calendars back to valid `.ics`
   - [x] Fold long lines correctly
-  - [ ] Escape text values correctly
+  - [x] Escape text values correctly
 - [ ] Validation
   - [ ] Validate required properties per component
   - [x] Validate mutually exclusive properties, such as `DTEND` and `DURATION`

--- a/Sources/iCalendarParser/Formatter/ICFormatter.swift
+++ b/Sources/iCalendarParser/Formatter/ICFormatter.swift
@@ -78,4 +78,31 @@ struct ICFormatter {
     ) -> String {
         lines.map(foldLine).joined(separator: "\r\n")
     }
+
+    /// Escapes a TEXT value for iCalendar serialization.
+    static func escapeTextValue(
+        _ value: String
+    ) -> String {
+        let normalizedValue = value
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+        var escaped = ""
+
+        for character in normalizedValue {
+            switch character {
+            case "\\":
+                escaped.append("\\\\")
+            case ";":
+                escaped.append("\\;")
+            case ",":
+                escaped.append("\\,")
+            case "\n":
+                escaped.append("\\n")
+            default:
+                escaped.append(character)
+            }
+        }
+
+        return escaped
+    }
 }

--- a/Tests/iCalendarParserTests/FormatterTests.swift
+++ b/Tests/iCalendarParserTests/FormatterTests.swift
@@ -43,4 +43,22 @@ final class FormatterTests: XCTestCase {
         XCTAssertTrue(folded.contains("SUMMARY:Short\r\nDESCRIPTION:"))
         XCTAssertTrue(folded.contains("\r\n "))
     }
+
+    func testEscapeTextValueEscapesReservedCharacters() {
+        let value = "Board, product; roadmap \\ review"
+
+        XCTAssertEqual(
+            ICFormatter.escapeTextValue(value),
+            "Board\\, product\\; roadmap \\\\ review"
+        )
+    }
+
+    func testEscapeTextValueEscapesLineBreaks() {
+        let value = "Line 1\r\nLine 2\rLine 3\nLine 4"
+
+        XCTAssertEqual(
+            ICFormatter.escapeTextValue(value),
+            "Line 1\\nLine 2\\nLine 3\\nLine 4"
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- Add iCalendar TEXT escaping for serialization helpers
- Escape backslash, comma, semicolon, and line breaks according to RFC 5545 TEXT rules
- Mark `Escape text values correctly` complete in the README roadmap

## Example ICS
Input values such as:

```swift
let summary = "Board, product; roadmap \ review"
let description = "Line 1\nLine 2"
```

can now be serialized as TEXT-safe property values:

```ics
BEGIN:VEVENT
UID:text-escape-test
DTSTAMP:20240728T120000Z
SUMMARY:Board\, product\; roadmap \\ review
DESCRIPTION:Line 1\nLine 2
END:VEVENT
```

## What becomes available
```swift
ICFormatter.escapeTextValue("Board, product; roadmap \ review")
// "Board\, product\; roadmap \\ review"
```

This prepares `.ics` serialization code to emit valid TEXT values without changing parser behavior.

## Validation
- `swift test`
- `swiftlint lint --quiet`