### PR TITLE
docs: mark duration value type complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ iCalendarParser is currently not feature complete yet. While it requires an addi
 - [ ] Value types
   - [x] Parse `DATE`
   - [x] Parse `DATE-TIME`
-  - [ ] Parse `DURATION`
+  - [x] Parse `DURATION`
   - [x] Parse `PERIOD`
   - [x] Parse `URI`
   - [x] Parse `UTC-OFFSET`


### PR DESCRIPTION
## Summary
- Mark `DURATION` value parsing as complete in the README roadmap
- Align the roadmap with the existing `ICDuration` parser and duration tests

## Example ICS
```ics
BEGIN:VEVENT
UID:duration-value-test
DTSTAMP:20240728T120000Z
DTSTART:20240728T120000Z
DURATION:P1DT2H30M
END:VEVENT
```

## What becomes available
This is a documentation correction. `ICDuration` parsing is already available and covered by tests for week, date-time, time-only, signed, and invalid duration values.

## Validation
- `swift test`
- `swiftlint lint --quiet`