### PR TITLE
feat: validate required properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ iCalendarParser is currently not feature complete yet. While it requires an addi
   - [x] Fold long lines correctly
   - [x] Escape text values correctly
 - [ ] Validation
-  - [ ] Validate required properties per component
+  - [x] Validate required properties per component
   - [x] Validate mutually exclusive properties, such as `DTEND` and `DURATION`
   - [ ] Validate property cardinality rules
 - [ ] Compatibility

--- a/Sources/iCalendarParser/Validation/ICValidationError.swift
+++ b/Sources/iCalendarParser/Validation/ICValidationError.swift
@@ -2,7 +2,9 @@ import Foundation
 
 public enum ICValidationError: Equatable {
     case missingProductIdentifier
+    case missingCalendarVersion
     case missingEventDateStamp(uid: String)
+    case missingEventDateStart(uid: String)
     case missingEventUID
     case mutuallyExclusiveEventDateEndAndDuration(uid: String)
 }

--- a/Sources/iCalendarParser/Validation/ICValidator.swift
+++ b/Sources/iCalendarParser/Validation/ICValidator.swift
@@ -12,6 +12,10 @@ public struct ICValidator {
             errors.append(.missingProductIdentifier)
         }
 
+        if calendar.version.isEmpty {
+            errors.append(.missingCalendarVersion)
+        }
+
         calendar.events.forEach { event in
             errors.append(contentsOf: validate(event))
         }
@@ -30,6 +34,10 @@ public struct ICValidator {
 
         if isMissingProperty(Constant.Property.dtStamp, in: event) {
             errors.append(.missingEventDateStamp(uid: event.uid))
+        }
+
+        if isMissingProperty(Constant.Property.dtStart, in: event) {
+            errors.append(.missingEventDateStart(uid: event.uid))
         }
 
         if event.dtEnd != nil, event.duration != nil {

--- a/Tests/iCalendarParserTests/ValidationTests.swift
+++ b/Tests/iCalendarParserTests/ValidationTests.swift
@@ -10,6 +10,17 @@ final class ValidationTests: XCTestCase {
         XCTAssertEqual(errors, [.missingProductIdentifier])
     }
 
+    func testCalendarValidationRequiresVersion() {
+        let calendar = ICalendar(
+            productId: ICProductIdentifier("-//Example Inc//Calendar//EN"),
+            version: ""
+        )
+
+        let errors = ICValidator().validate(calendar)
+
+        XCTAssertEqual(errors, [.missingCalendarVersion])
+    }
+
     func testEventValidationRequiresUIDWhenParsedPropertiesAreAvailable() throws {
         let calendar = try XCTUnwrap(ICParser().calendar(from: """
         BEGIN:VCALENDAR\r
@@ -17,6 +28,7 @@ final class ValidationTests: XCTestCase {
         PRODID:-//Example Inc//Calendar//EN\r
         BEGIN:VEVENT\r
         DTSTAMP:20240728T120000Z\r
+        DTSTART:20240728T120000Z\r
         END:VEVENT\r
         END:VCALENDAR
         """))
@@ -33,6 +45,7 @@ final class ValidationTests: XCTestCase {
         PRODID:-//Example Inc//Calendar//EN\r
         BEGIN:VEVENT\r
         UID:missing-dtstamp-test\r
+        DTSTART:20240728T120000Z\r
         END:VEVENT\r
         END:VCALENDAR
         """))
@@ -40,6 +53,23 @@ final class ValidationTests: XCTestCase {
         let errors = ICValidator().validate(calendar)
 
         XCTAssertEqual(errors, [.missingEventDateStamp(uid: "missing-dtstamp-test")])
+    }
+
+    func testEventValidationRequiresDateStartWhenParsedPropertiesAreAvailable() throws {
+        let calendar = try XCTUnwrap(ICParser().calendar(from: """
+        BEGIN:VCALENDAR\r
+        VERSION:2.0\r
+        PRODID:-//Example Inc//Calendar//EN\r
+        BEGIN:VEVENT\r
+        UID:missing-dtstart-test\r
+        DTSTAMP:20240728T120000Z\r
+        END:VEVENT\r
+        END:VCALENDAR
+        """))
+
+        let errors = ICValidator().validate(calendar)
+
+        XCTAssertEqual(errors, [.missingEventDateStart(uid: "missing-dtstart-test")])
     }
 
     func testEventValidationRejectsDateEndAndDurationTogether() {


### PR DESCRIPTION
## Summary
- Add validation errors for missing calendar `VERSION` and event `DTSTART`
- Keep existing required-property validation for `PRODID`, `UID`, and `DTSTAMP`
- Mark required-property validation complete in the README roadmap

## Example ICS
```ics
BEGIN:VEVENT
UID:missing-dtstart-test
DTSTAMP:20240728T120000Z
END:VEVENT
```

## What becomes available
```swift
let errors = ICValidator().validate(calendar)
// includes .missingEventDateStart(uid: "missing-dtstart-test")
```

Calendar validation also reports `.missingCalendarVersion` when `version` is empty.

## Validation
- `swift test`
- `swiftlint lint --quiet`