### PR TITLE
feat: preserve x-property parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ iCalendarParser is currently not feature complete yet. While it requires an addi
   - [ ] Validate property cardinality rules
 - [ ] Compatibility
   - [ ] Preserve unknown standard properties
-  - [ ] Preserve `X-` properties and parameters
+  - [x] Preserve `X-` properties and parameters
   - [ ] Add fixture coverage from real-world calendars
 
 ## Contributing

--- a/Sources/iCalendarParser/Models/ICComponent.swift
+++ b/Sources/iCalendarParser/Models/ICComponent.swift
@@ -179,6 +179,15 @@ struct ICComponent {
         return dict
     }
 
+    /// Returns all non-standard properties, including parameters.
+    func getNonStandardPropertyDetails() -> [ICProperty]? {
+        let properties = properties.filter {
+            $0.baseName.hasPrefix("X-")
+        }
+
+        return properties.isEmpty ? nil : properties
+    }
+
     // MARK: - Private functions
 
     /// Returns a property that matches the name in the given properties

--- a/Sources/iCalendarParser/Models/ICEvent.swift
+++ b/Sources/iCalendarParser/Models/ICEvent.swift
@@ -112,6 +112,9 @@ public struct ICEvent: ICComponentable {
     /// https://www.rfc-editor.org/rfc/rfc5545#section-3.8.8.2)
     public var nonStandardProperties: [String: String]?
 
+    /// Any property with an "X-" prefix, including parameters.
+    public var nonStandardPropertyDetails: [ICProperty]?
+
     /// Specifies the date and time that the information associated with the calendar
     /// component was last revised in the calendar store.
     ///
@@ -236,6 +239,7 @@ public struct ICEvent: ICComponentable {
         lastModified: Date? = nil,
         location: String? = nil,
         nonStandardProperties: [String: String]? = nil,
+        nonStandardPropertyDetails: [ICProperty]? = nil,
         organizer: String? = nil,
         priority: Int? = nil,
         properties: [ICProperty]? = nil,
@@ -268,6 +272,7 @@ public struct ICEvent: ICComponentable {
         self.lastModified = lastModified
         self.location = location
         self.nonStandardProperties = nonStandardProperties
+        self.nonStandardPropertyDetails = nonStandardPropertyDetails
         self.organizer = organizer
         self.priority = priority
         self.properties = properties

--- a/Sources/iCalendarParser/Models/ICTimeZone.swift
+++ b/Sources/iCalendarParser/Models/ICTimeZone.swift
@@ -16,6 +16,9 @@ public struct ICTimeZone: ICComponentable {
     /// https://www.rfc-editor.org/rfc/rfc5545#section-3.8.8.2)
     public var nonStandardProperties: [String: String]?
 
+    /// Any property with an "X-" prefix, including parameters.
+    public var nonStandardPropertyDetails: [ICProperty]?
+
     public var standard: ICSubTimeZone?
 
     /// Specifies the text value that uniquely identifies the "VTIMEZONE" calendar
@@ -35,12 +38,14 @@ public struct ICTimeZone: ICComponentable {
     public init(
         daylight: ICSubTimeZone? = nil,
         nonStandardProperties: [String: String]? = nil,
+        nonStandardPropertyDetails: [ICProperty]? = nil,
         standard: ICSubTimeZone? = nil,
         timeZoneId: String,
         timeZoneUrl: URL? = nil
     ) {
         self.daylight = daylight
         self.nonStandardProperties = nonStandardProperties
+        self.nonStandardPropertyDetails = nonStandardPropertyDetails
         self.standard = standard
         self.timeZoneId = timeZoneId
         self.timeZoneUrl = timeZoneUrl

--- a/Sources/iCalendarParser/Parser/ICParser.swift
+++ b/Sources/iCalendarParser/Parser/ICParser.swift
@@ -183,6 +183,7 @@ public struct ICParser {
             event.recurrenceRule = component.buildProperty(of: Constant.Property.recurrenceRule)
 
             event.nonStandardProperties = component.getNonStandardProperties()
+            event.nonStandardPropertyDetails = component.getNonStandardPropertyDetails()
 
             return event
         }
@@ -222,10 +223,12 @@ public struct ICParser {
             }
 
             let nonStandardProperties = component.getNonStandardProperties()
+            let nonStandardPropertyDetails = component.getNonStandardPropertyDetails()
 
             return ICTimeZone(
                 daylight: daylight,
                 nonStandardProperties: nonStandardProperties,
+                nonStandardPropertyDetails: nonStandardPropertyDetails,
                 standard: standard,
                 timeZoneId: tzid
             )

--- a/Tests/iCalendarParserTests/NonStandardPropertyTests.swift
+++ b/Tests/iCalendarParserTests/NonStandardPropertyTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+@testable import iCalendarParser
+
+final class NonStandardPropertyTests: XCTestCase {
+    func testEventExposesNonStandardPropertyParameters() throws {
+        let iCalString = """
+        BEGIN:VCALENDAR\r
+        VERSION:2.0\r
+        PRODID:-//Example Inc//Calendar//EN\r
+        BEGIN:VEVENT\r
+        UID:x-property-test\r
+        DTSTAMP:20240728T120000Z\r
+        X-APPLE-STRUCTURED-LOCATION;VALUE=URI;X-ADDRESS="1 Infinite Loop":geo:37.3317,-122.0301\r
+        END:VEVENT\r
+        END:VCALENDAR
+        """
+
+        let calendar = try XCTUnwrap(ICParser().calendar(from: iCalString))
+        let event = try XCTUnwrap(calendar.events.first)
+        let property = try XCTUnwrap(event.nonStandardPropertyDetails?.first)
+
+        XCTAssertEqual(property.baseName, "X-APPLE-STRUCTURED-LOCATION")
+        XCTAssertEqual(property.value, "geo:37.3317,-122.0301")
+        XCTAssertEqual(property.parameters.first(where: { $0.name == "VALUE" })?.value, "URI")
+        XCTAssertEqual(property.parameters.first(where: { $0.name == "X-ADDRESS" })?.value, "1 Infinite Loop")
+    }
+
+    func testTimeZoneExposesNonStandardPropertyParameters() throws {
+        let iCalString = """
+        BEGIN:VCALENDAR\r
+        VERSION:2.0\r
+        PRODID:-//Example Inc//Calendar//EN\r
+        BEGIN:VTIMEZONE\r
+        TZID:America/Los_Angeles\r
+        X-LIC-LOCATION;LANGUAGE=en:America/Los_Angeles\r
+        BEGIN:STANDARD\r
+        DTSTART:20241103T020000\r
+        TZOFFSETFROM:-0700\r
+        TZOFFSETTO:-0800\r
+        END:STANDARD\r
+        END:VTIMEZONE\r
+        END:VCALENDAR
+        """
+
+        let calendar = try XCTUnwrap(ICParser().calendar(from: iCalString))
+        let timeZone = try XCTUnwrap(calendar.timeZones.first)
+        let property = try XCTUnwrap(timeZone.nonStandardPropertyDetails?.first)
+
+        XCTAssertEqual(property.baseName, "X-LIC-LOCATION")
+        XCTAssertEqual(property.value, "America/Los_Angeles")
+        XCTAssertEqual(property.parameters.first(where: { $0.name == "LANGUAGE" })?.value, "en")
+    }
+}


### PR DESCRIPTION
## Summary
- Add `nonStandardPropertyDetails` to events and time zones
- Preserve full `X-` properties as `ICProperty` values, including parameters
- Keep existing `nonStandardProperties` dictionary API unchanged
- Mark `X-` property and parameter preservation complete in the README roadmap

## Example ICS
```ics
BEGIN:VEVENT
UID:x-property-test
DTSTAMP:20240728T120000Z
X-APPLE-STRUCTURED-LOCATION;VALUE=URI;X-ADDRESS="1 Infinite Loop":geo:37.3317,-122.0301
END:VEVENT
```

## What becomes available
```swift
let property = event.nonStandardPropertyDetails?.first
property?.baseName // "X-APPLE-STRUCTURED-LOCATION"
property?.parameters.first { $0.name == "VALUE" }?.value // "URI"
property?.parameters.first { $0.name == "X-ADDRESS" }?.value // "1 Infinite Loop"
```

The same detail API is available on `ICTimeZone` for `X-` properties inside `VTIMEZONE`.

## Validation
- `swift test`
- `swiftlint lint --quiet`