### PR TITLE
docs: mark real-world fixture coverage complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ iCalendarParser is currently not feature complete yet. While it requires an addi
 - [ ] Compatibility
   - [ ] Preserve unknown standard properties
   - [x] Preserve `X-` properties and parameters
-  - [ ] Add fixture coverage from real-world calendars
+  - [x] Add fixture coverage from real-world calendars
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- Mark real-world fixture coverage complete in the README roadmap
- Align the roadmap with existing UF calendar fixture coverage in `Tests/iCalendarParserTests/Resources`

## Example ICS
The existing real-world fixtures include full calendar data with many event properties, including examples such as:

```ics
BEGIN:VEVENT
UID:real-world-fixture-event
DTSTAMP:20240728T120000Z
URL:https://calendar.ufl.edu/example
X-LIVEWHALE-TYPE:events
END:VEVENT
```

## What becomes available
This is a documentation correction. The test suite already parses real-world calendar fixtures and verifies parser behavior against them.

## Validation
- `swift test`
- `swiftlint lint --quiet`