### PR TITLE
feat: preserve unknown standard properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ iCalendarParser is currently not feature complete yet. While it requires an addi
   - [x] Validate mutually exclusive properties, such as `DTEND` and `DURATION`
   - [ ] Validate property cardinality rules
 - [ ] Compatibility
-  - [ ] Preserve unknown standard properties
+  - [x] Preserve unknown standard properties
   - [x] Preserve `X-` properties and parameters
   - [ ] Add fixture coverage from real-world calendars
 

--- a/Tests/iCalendarParserTests/UnknownStandardPropertyTests.swift
+++ b/Tests/iCalendarParserTests/UnknownStandardPropertyTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+@testable import iCalendarParser
+
+final class UnknownStandardPropertyTests: XCTestCase {
+    func testEventPreservesUnknownStandardPropertyAndParameters() throws {
+        let iCalString = """
+        BEGIN:VCALENDAR\r
+        VERSION:2.0\r
+        PRODID:-//Example Inc//Calendar//EN\r
+        BEGIN:VEVENT\r
+        UID:unknown-standard-property-test\r
+        DTSTAMP:20240728T120000Z\r
+        DTSTART:20240728T120000Z\r
+        COLOR;VALUE=TEXT:turquoise\r
+        END:VEVENT\r
+        END:VCALENDAR
+        """
+
+        let calendar = try XCTUnwrap(ICParser().calendar(from: iCalString))
+        let event = try XCTUnwrap(calendar.events.first)
+        let color = try XCTUnwrap(event.properties?.first { $0.baseName == "COLOR" })
+
+        XCTAssertEqual(color.value, "turquoise")
+        XCTAssertEqual(color.parameters.first { $0.name == "VALUE" }?.value, "TEXT")
+    }
+}


### PR DESCRIPTION
## Summary
- Add focused coverage proving unknown standard properties remain available through `event.properties`
- Cover preservation of both property value and parameters
- Mark unknown standard property preservation complete in the README roadmap

## Example ICS
```ics
BEGIN:VEVENT
UID:unknown-standard-property-test
DTSTAMP:20240728T120000Z
DTSTART:20240728T120000Z
COLOR;VALUE=TEXT:turquoise
END:VEVENT
```

## What becomes available
```swift
let color = event.properties?.first { $0.baseName == "COLOR" }
color?.value // "turquoise"
color?.parameters.first { $0.name == "VALUE" }?.value // "TEXT"
```

This keeps unknown-but-standard properties accessible without adding dedicated model fields for every property.

## Validation
- `swift test`
- `swiftlint lint --quiet`