### PR TITLE
feat: validate property cardinality

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ iCalendarParser is currently not feature complete yet. While it requires an addi
 - [ ] Validation
   - [x] Validate required properties per component
   - [x] Validate mutually exclusive properties, such as `DTEND` and `DURATION`
-  - [ ] Validate property cardinality rules
+  - [x] Validate property cardinality rules
 - [ ] Compatibility
   - [ ] Preserve unknown standard properties
   - [x] Preserve `X-` properties and parameters

--- a/Sources/iCalendarParser/Validation/ICValidationError.swift
+++ b/Sources/iCalendarParser/Validation/ICValidationError.swift
@@ -7,4 +7,5 @@ public enum ICValidationError: Equatable {
     case missingEventDateStart(uid: String)
     case missingEventUID
     case mutuallyExclusiveEventDateEndAndDuration(uid: String)
+    case duplicateEventProperty(uid: String, propertyName: String)
 }

--- a/Sources/iCalendarParser/Validation/ICValidator.swift
+++ b/Sources/iCalendarParser/Validation/ICValidator.swift
@@ -3,6 +3,28 @@ import Foundation
 public struct ICValidator {
     public init() {}
 
+    private let singleEventPropertyNames = [
+        Constant.Property.classification,
+        Constant.Property.created,
+        Constant.Property.description,
+        Constant.Property.dtEnd,
+        Constant.Property.dtStamp,
+        Constant.Property.dtStart,
+        Constant.Property.duration,
+        Constant.Property.geoPosition,
+        Constant.Property.lastModified,
+        Constant.Property.location,
+        Constant.Property.organizer,
+        Constant.Property.priority,
+        Constant.Property.recurrenceId,
+        Constant.Property.sequence,
+        Constant.Property.status,
+        Constant.Property.summary,
+        Constant.Property.timeTransparency,
+        Constant.Property.uid,
+        Constant.Property.url
+    ]
+
     public func validate(
         _ calendar: ICalendar
     ) -> [ICValidationError] {
@@ -44,6 +66,8 @@ public struct ICValidator {
             errors.append(.mutuallyExclusiveEventDateEndAndDuration(uid: event.uid))
         }
 
+        errors.append(contentsOf: validateCardinality(event))
+
         return errors
     }
 
@@ -56,5 +80,23 @@ public struct ICValidator {
         }
 
         return !properties.contains { $0.baseName == name }
+    }
+
+    private func validateCardinality(
+        _ event: ICEvent
+    ) -> [ICValidationError] {
+        guard let properties = event.properties else {
+            return []
+        }
+
+        return singleEventPropertyNames.compactMap { propertyName in
+            let count = properties.filter { $0.baseName == propertyName }.count
+
+            guard count > 1 else {
+                return nil
+            }
+
+            return .duplicateEventProperty(uid: event.uid, propertyName: propertyName)
+        }
     }
 }

--- a/Tests/iCalendarParserTests/ValidationTests.swift
+++ b/Tests/iCalendarParserTests/ValidationTests.swift
@@ -86,4 +86,48 @@ final class ValidationTests: XCTestCase {
             [.mutuallyExclusiveEventDateEndAndDuration(uid: "mutually-exclusive-test")]
         )
     }
+
+    func testEventValidationRejectsDuplicateUniqueIdentifier() throws {
+        let calendar = try XCTUnwrap(ICParser().calendar(from: """
+        BEGIN:VCALENDAR\r
+        VERSION:2.0\r
+        PRODID:-//Example Inc//Calendar//EN\r
+        BEGIN:VEVENT\r
+        UID:duplicate-uid-test\r
+        UID:duplicate-uid-test-copy\r
+        DTSTAMP:20240728T120000Z\r
+        DTSTART:20240728T120000Z\r
+        END:VEVENT\r
+        END:VCALENDAR
+        """))
+
+        let errors = ICValidator().validate(calendar)
+
+        XCTAssertEqual(
+            errors,
+            [.duplicateEventProperty(uid: "duplicate-uid-test", propertyName: "UID")]
+        )
+    }
+
+    func testEventValidationRejectsDuplicateDateStart() throws {
+        let calendar = try XCTUnwrap(ICParser().calendar(from: """
+        BEGIN:VCALENDAR\r
+        VERSION:2.0\r
+        PRODID:-//Example Inc//Calendar//EN\r
+        BEGIN:VEVENT\r
+        UID:duplicate-dtstart-test\r
+        DTSTAMP:20240728T120000Z\r
+        DTSTART:20240728T120000Z\r
+        DTSTART:20240729T120000Z\r
+        END:VEVENT\r
+        END:VCALENDAR
+        """))
+
+        let errors = ICValidator().validate(calendar)
+
+        XCTAssertEqual(
+            errors,
+            [.duplicateEventProperty(uid: "duplicate-dtstart-test", propertyName: "DTSTART")]
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- Add `duplicateEventProperty` validation errors
- Validate common single-instance `VEVENT` properties such as `UID`, `DTSTAMP`, `DTSTART`, `DTEND`, `DURATION`, and `SUMMARY`
- Mark property cardinality validation complete in the README roadmap

## Example ICS
```ics
BEGIN:VEVENT
UID:duplicate-dtstart-test
DTSTAMP:20240728T120000Z
DTSTART:20240728T120000Z
DTSTART:20240729T120000Z
END:VEVENT
```

## What becomes available
```swift
let errors = ICValidator().validate(calendar)
// includes .duplicateEventProperty(uid: "duplicate-dtstart-test", propertyName: "DTSTART")
```

## Validation
- `swift test`
- `swiftlint lint --quiet`