### PR TITLE
feat: format calendars

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ iCalendarParser is currently not feature complete yet. While it requires an addi
   - [x] Parse `URI`
   - [x] Parse `UTC-OFFSET`
 - [ ] Serialization
-  - [ ] Format calendars back to valid `.ics`
+  - [x] Format calendars back to valid `.ics`
   - [x] Fold long lines correctly
   - [x] Escape text values correctly
 - [ ] Validation

--- a/Sources/iCalendarParser/Formatter/ICFormatter.swift
+++ b/Sources/iCalendarParser/Formatter/ICFormatter.swift
@@ -1,8 +1,31 @@
 import Foundation
 
-struct ICFormatter {
+public struct ICFormatter {
     static let maxLineLength = 75
     private static let continuationPrefix = " "
+
+    public init() {}
+
+    /// Formats an iCalendar object as valid `.ics` text.
+    public static func format(
+        _ calendar: ICalendar
+    ) -> String {
+        var lines = [
+            "BEGIN:VCALENDAR",
+            "VERSION:\(calendar.version)",
+            "PRODID:\(calendar.productId.raw)"
+        ]
+
+        appendTextLine("CALSCALE", calendar.calendarScale, to: &lines)
+        appendTextLine("METHOD", calendar.method, to: &lines)
+
+        calendar.events.forEach { event in
+            lines.append(contentsOf: formatEvent(event))
+        }
+
+        lines.append("END:VCALENDAR")
+        return foldLines(lines)
+    }
 
     /// Returns a configured `DateFormatter` based on `ICDateTimeType`
     static func dateFormatter(
@@ -80,7 +103,7 @@ struct ICFormatter {
     }
 
     /// Escapes a TEXT value for iCalendar serialization.
-    static func escapeTextValue(
+    public static func escapeTextValue(
         _ value: String
     ) -> String {
         let normalizedValue = value
@@ -104,5 +127,130 @@ struct ICFormatter {
         }
 
         return escaped
+    }
+
+    private static func formatEvent(
+        _ event: ICEvent
+    ) -> [String] {
+        var lines = ["BEGIN:VEVENT"]
+
+        appendTextLine("UID", event.uid, to: &lines)
+        lines.append("DTSTAMP:\(DateTimeType.dateTime.dateFormatter().string(from: event.dtStamp))")
+        appendDateTimeLine("DTSTART", event.dtStart, to: &lines)
+        appendDateTimeLine("DTEND", event.dtEnd, to: &lines)
+        appendRawLine("DURATION", event.duration?.rawValue, to: &lines)
+        appendTextLine("SUMMARY", event.summary, to: &lines)
+        appendTextLine("DESCRIPTION", event.description, to: &lines)
+        appendTextLine("LOCATION", event.location, to: &lines)
+        appendTextLine("CLASS", event.classification, to: &lines)
+        appendTextLine("STATUS", event.status, to: &lines)
+        appendTextLine("TRANSP", event.timeTransparency, to: &lines)
+        appendIntegerLine("PRIORITY", event.priority, to: &lines)
+        appendIntegerLine("SEQUENCE", event.sequence, to: &lines)
+        appendTextListLine("CATEGORIES", event.categories, to: &lines)
+        appendTextListLines("COMMENT", event.comments, to: &lines)
+        appendTextListLines("CONTACT", event.contacts, to: &lines)
+        appendTextListLines("RESOURCES", event.resources, to: &lines)
+        appendDateTimeLines("EXDATE", event.exceptionDates, to: &lines)
+        appendDateTimeLines("RDATE", event.recurrenceDates, to: &lines)
+        appendRawLine("URL", event.url?.absoluteString, to: &lines)
+
+        lines.append("END:VEVENT")
+        return lines
+    }
+
+    private static func appendTextLine(
+        _ name: String,
+        _ value: String?,
+        to lines: inout [String]
+    ) {
+        guard let value else {
+            return
+        }
+
+        lines.append("\(name):\(escapeTextValue(value))")
+    }
+
+    private static func appendRawLine(
+        _ name: String,
+        _ value: String?,
+        to lines: inout [String]
+    ) {
+        guard let value else {
+            return
+        }
+
+        lines.append("\(name):\(value)")
+    }
+
+    private static func appendTextListLine(
+        _ name: String,
+        _ values: [String]?,
+        to lines: inout [String]
+    ) {
+        guard let values, !values.isEmpty else {
+            return
+        }
+
+        lines.append("\(name):\(values.map(escapeTextValue).joined(separator: ","))")
+    }
+
+    private static func appendTextListLines(
+        _ name: String,
+        _ values: [String]?,
+        to lines: inout [String]
+    ) {
+        values?.forEach { value in
+            appendTextLine(name, value, to: &lines)
+        }
+    }
+
+    private static func appendIntegerLine(
+        _ name: String,
+        _ value: Int?,
+        to lines: inout [String]
+    ) {
+        guard let value else {
+            return
+        }
+
+        lines.append("\(name):\(value)")
+    }
+
+    private static func appendDateTimeLine(
+        _ name: String,
+        _ value: ICDateTime?,
+        to lines: inout [String]
+    ) {
+        guard let value else {
+            return
+        }
+
+        lines.append(dateTimeLine(name, value))
+    }
+
+    private static func appendDateTimeLines(
+        _ name: String,
+        _ values: [ICDateTime]?,
+        to lines: inout [String]
+    ) {
+        values?.forEach { value in
+            lines.append(dateTimeLine(name, value))
+        }
+    }
+
+    private static func dateTimeLine(
+        _ name: String,
+        _ value: ICDateTime
+    ) -> String {
+        var propertyName = name
+
+        if value.type == .date {
+            propertyName += ";VALUE=DATE"
+        } else if let tzId = value.tzId {
+            propertyName += ";TZID=\(tzId)"
+        }
+
+        return "\(propertyName):\(value.type.dateFormatter(tzId: value.tzId).string(from: value.date))"
     }
 }

--- a/Tests/iCalendarParserTests/FormatterTests.swift
+++ b/Tests/iCalendarParserTests/FormatterTests.swift
@@ -2,6 +2,45 @@ import XCTest
 @testable import iCalendarParser
 
 final class FormatterTests: XCTestCase {
+    func testFormatCalendarWithEvent() throws {
+        let stamp = try XCTUnwrap(DateTimeType.dateTime.dateFormatter().date(from: "20240728T120000Z"))
+        let start = try XCTUnwrap(DateTimeType.date.dateFormatter().date(from: "20240729"))
+        let calendar = ICalendar(
+            events: [
+                ICEvent(
+                    categories: ["Board, Executive", "Planning"],
+                    description: "Line 1\nLine 2",
+                    dtStamp: stamp,
+                    dtStart: .date(from: start),
+                    location: "Room 1; East",
+                    summary: "Board, product; roadmap",
+                    uid: "format-test",
+                    url: URL(string: "https://example.com/events/1?source=calendar")
+                )
+            ],
+            productId: ICProductIdentifier("-//Example Inc//Calendar//EN")
+        )
+
+        let formatted = ICFormatter.format(calendar)
+
+        XCTAssertTrue(formatted.contains("BEGIN:VCALENDAR\r\n"))
+        XCTAssertTrue(formatted.contains("VERSION:2.0\r\n"))
+        XCTAssertTrue(formatted.contains("PRODID:-//Example Inc//Calendar//EN\r\n"))
+        XCTAssertTrue(formatted.contains("BEGIN:VEVENT\r\n"))
+        XCTAssertTrue(formatted.contains("UID:format-test\r\n"))
+        XCTAssertTrue(formatted.contains("DTSTAMP:20240728T120000Z\r\n"))
+        XCTAssertTrue(formatted.contains("DTSTART;VALUE=DATE:20240729\r\n"))
+        XCTAssertTrue(formatted.contains("SUMMARY:Board\\, product\\; roadmap\r\n"))
+        XCTAssertTrue(formatted.contains("DESCRIPTION:Line 1\\nLine 2\r\n"))
+        XCTAssertTrue(formatted.contains("LOCATION:Room 1\\; East\r\n"))
+        XCTAssertTrue(formatted.contains("CATEGORIES:Board\\, Executive,Planning\r\n"))
+        XCTAssertTrue(formatted.contains("URL:https://example.com/events/1?source=calendar\r\n"))
+        XCTAssertTrue(formatted.hasSuffix("END:VCALENDAR"))
+
+        let parsed = try XCTUnwrap(ICParser().calendar(from: formatted))
+        XCTAssertEqual(parsed.events.first?.uid, "format-test")
+    }
+
     func testFoldLineKeepsShortLineUnchanged() {
         let line = "SUMMARY:Board meeting"
 


### PR DESCRIPTION
## Summary
- Add public `ICFormatter.format(_:)` support for serializing calendars to `.ics` text
- Serialize core calendar fields and supported `VEVENT` fields
- Reuse TEXT escaping and line folding so generated output is parser-compatible
- Mark calendar formatting complete in the README roadmap

## Example ICS
Given an `ICalendar` with an event, formatting can produce output like:

```ics
BEGIN:VCALENDAR
VERSION:2.0
PRODID:-//Example Inc//Calendar//EN
CALSCALE:GREGORIAN
BEGIN:VEVENT
UID:format-test
DTSTAMP:20240728T120000Z
DTSTART;VALUE=DATE:20240729
SUMMARY:Board\, product\; roadmap
DESCRIPTION:Line 1\nLine 2
END:VEVENT
END:VCALENDAR
```

## What becomes available
```swift
let ics = ICFormatter.format(calendar)
let parsed = ICParser().calendar(from: ics)
```

The formatter currently covers supported calendar fields and supported `VEVENT` fields, including TEXT escaping, DATE/DATE-TIME values, URI values, text lists, and folded content lines.

## Validation
- `swift test`
- `swiftlint lint --quiet`