### PR TITLE
feat: parse vtodo components

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ iCalendarParser is currently not feature complete yet. While it requires an addi
 - [ ] Components
   - [x] Parse `VEVENT`
   - [x] Parse `VTIMEZONE`
-  - [ ] Parse `VTODO`
+  - [x] Parse `VTODO`
   - [ ] Parse `VJOURNAL`
   - [ ] Parse `VFREEBUSY`
   - [ ] Parse `VALARM`

--- a/Sources/iCalendarParser/Constant/Constant.swift
+++ b/Sources/iCalendarParser/Constant/Constant.swift
@@ -9,6 +9,7 @@ public enum Constant {
         public static let daylight = "DAYLIGHT"
         public static let event = "VEVENT"
         public static let timeZone = "VTIMEZONE"
+        public static let todo = "VTODO"
         public static let standard = "STANDARD"
     }
 
@@ -72,6 +73,7 @@ extension Constant {
         static let created: String = "CREATED"
         static let classification: String = "CLASS"
         static let description: String = "DESCRIPTION"
+        static let due: String = "DUE"
         static let dtStart: String = "DTSTART"
         static let dtEnd: String = "DTEND"
         static let dtStamp: String = "DTSTAMP"
@@ -81,6 +83,7 @@ extension Constant {
         static let lastModified: String = "LAST-MODIFIED"
         static let location: String = "LOCATION"
         static let organizer: String = "ORGANIZER"
+        static let percentComplete: String = "PERCENT-COMPLETE"
         static let priority: String = "PRIORITY"
         static let relatedTo: String = "RELATED-TO"
         static let recurrenceDates: String = "RDATE"

--- a/Sources/iCalendarParser/Models/ICComponentType.swift
+++ b/Sources/iCalendarParser/Models/ICComponentType.swift
@@ -5,6 +5,7 @@ enum ICComponentType {
     case alarm
     case event
     case timeZone
+    case todo
 
     var name: String {
         switch self {
@@ -14,6 +15,8 @@ enum ICComponentType {
             return Constant.Component.event
         case .timeZone:
             return Constant.Component.timeZone
+        case .todo:
+            return Constant.Component.todo
         }
     }
 }

--- a/Sources/iCalendarParser/Models/ICToDo.swift
+++ b/Sources/iCalendarParser/Models/ICToDo.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// A grouping of component properties that describe a to-do.
+///
+/// See more in [RFC 5545](
+/// https://www.rfc-editor.org/rfc/rfc5545#section-3.6.2)
+public struct ICToDo: ICComponentable, Equatable {
+
+    let type: ICComponentType = .todo
+
+    public var description: String?
+    public var dtStamp: Date?
+    public var dtStart: ICDateTime?
+    public var due: ICDateTime?
+    public var percentComplete: Int?
+    public var priority: Int?
+    public var properties: [ICProperty]?
+    public var status: String?
+    public var summary: String?
+    public var uid: String
+
+    public init(
+        description: String? = nil,
+        dtStamp: Date? = nil,
+        dtStart: ICDateTime? = nil,
+        due: ICDateTime? = nil,
+        percentComplete: Int? = nil,
+        priority: Int? = nil,
+        properties: [ICProperty]? = nil,
+        status: String? = nil,
+        summary: String? = nil,
+        uid: String = ""
+    ) {
+        self.description = description
+        self.dtStamp = dtStamp
+        self.dtStart = dtStart
+        self.due = due
+        self.percentComplete = percentComplete
+        self.priority = priority
+        self.properties = properties
+        self.status = status
+        self.summary = summary
+        self.uid = uid
+    }
+}

--- a/Sources/iCalendarParser/Models/ICalendar.swift
+++ b/Sources/iCalendarParser/Models/ICalendar.swift
@@ -7,7 +7,7 @@ import Foundation
 public struct ICalendar {
 
     var components: [ICComponentable] {
-        [events, timeZones]
+        [events, timeZones, todos]
             .compactMap { $0 as? [ICComponentable] }
             .flatMap { $0 }
     }
@@ -46,6 +46,9 @@ public struct ICalendar {
     /// one time zone and end in another.
     public var timeZones: [ICTimeZone]
 
+    /// All the to-do components in the object.
+    public var todos: [ICToDo]
+
     /// Returns an event only when there is one event component
     public var uniqueEvent: ICEvent? {
         guard events.count == 1 else {
@@ -77,6 +80,7 @@ public struct ICalendar {
         method: String? = nil,
         productId: ICProductIdentifier,
         timeZones: [ICTimeZone] = [],
+        todos: [ICToDo] = [],
         version: String = Constant.ICalSpec.version
     ) {
         self.calendarScale = calendarScale
@@ -84,6 +88,7 @@ public struct ICalendar {
         self.method = method
         self.productId = productId
         self.timeZones = timeZones
+        self.todos = todos
         self.version = version
     }
 }
@@ -95,6 +100,7 @@ extension ICalendar: Equatable {
         && lhs.method == rhs.method
         && lhs.productId == rhs.productId
         && lhs.timeZones == rhs.timeZones
+        && lhs.todos == rhs.todos
         && lhs.version == rhs.version
     }
 }

--- a/Sources/iCalendarParser/Parser/ICParser.swift
+++ b/Sources/iCalendarParser/Parser/ICParser.swift
@@ -46,15 +46,22 @@ public struct ICParser {
             from: elements
         )
 
+        let todoComponents = getComponents(
+            type: .todo,
+            from: elements
+        )
+
         let events = buildEvents(from: eventComponents)
         let timeZones = buildTimeZones(from: timeZoneComponents)
+        let todos = buildToDos(from: todoComponents)
 
         return ICalendar(
             calendarScale: calendarScale,
             events: events,
             method: method,
             productId: prodId,
-            timeZones: timeZones
+            timeZones: timeZones,
+            todos: todos
         )
     }
 
@@ -231,6 +238,25 @@ public struct ICParser {
                 nonStandardPropertyDetails: nonStandardPropertyDetails,
                 standard: standard,
                 timeZoneId: tzid
+            )
+        }
+    }
+
+    private func buildToDos(
+        from components: [ICComponent]
+    ) -> [ICToDo] {
+        components.map { component in
+            ICToDo(
+                description: component.buildProperty(of: Constant.Property.description),
+                dtStamp: component.buildProperty(of: Constant.Property.dtStamp)?.date,
+                dtStart: component.buildProperty(of: Constant.Property.dtStart),
+                due: component.buildProperty(of: Constant.Property.due),
+                percentComplete: component.buildProperty(of: Constant.Property.percentComplete),
+                priority: component.buildProperty(of: Constant.Property.priority),
+                properties: component.contentProperties,
+                status: component.buildProperty(of: Constant.Property.status),
+                summary: component.buildProperty(of: Constant.Property.summary),
+                uid: component.buildProperty(of: Constant.Property.uid) ?? ""
             )
         }
     }

--- a/Tests/iCalendarParserTests/ToDoTests.swift
+++ b/Tests/iCalendarParserTests/ToDoTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import iCalendarParser
+
+final class ToDoTests: XCTestCase {
+    func testParserBuildsToDoComponent() throws {
+        let iCalString = """
+        BEGIN:VCALENDAR\r
+        VERSION:2.0\r
+        PRODID:-//Example Inc//Calendar//EN\r
+        BEGIN:VTODO\r
+        UID:todo-test\r
+        DTSTAMP:20240728T120000Z\r
+        DTSTART:20240729T090000Z\r
+        DUE:20240730T170000Z\r
+        SUMMARY:Submit report\r
+        DESCRIPTION:Prepare quarterly update\r
+        STATUS:IN-PROCESS\r
+        PERCENT-COMPLETE:50\r
+        PRIORITY:3\r
+        END:VTODO\r
+        END:VCALENDAR
+        """
+
+        let calendar = try XCTUnwrap(ICParser().calendar(from: iCalString))
+        let todo = try XCTUnwrap(calendar.todos.first)
+
+        XCTAssertEqual(calendar.todos.count, 1)
+        XCTAssertEqual(todo.uid, "todo-test")
+        XCTAssertEqual(todo.summary, "Submit report")
+        XCTAssertEqual(todo.description, "Prepare quarterly update")
+        XCTAssertEqual(todo.status, "IN-PROCESS")
+        XCTAssertEqual(todo.percentComplete, 50)
+        XCTAssertEqual(todo.priority, 3)
+        XCTAssertEqual(format(todo.dtStart), "20240729T090000Z")
+        XCTAssertEqual(format(todo.due), "20240730T170000Z")
+        XCTAssertNotNil(todo.properties?.first { $0.baseName == "SUMMARY" })
+    }
+
+    private func format(
+        _ dateTime: ICDateTime?
+    ) -> String? {
+        dateTime.map {
+            $0.type.dateFormatter(tzId: $0.tzId).string(from: $0.date)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add an `ICToDo` model for parsed `VTODO` components
- Parse common to-do fields including `UID`, `DTSTAMP`, `DTSTART`, `DUE`, `SUMMARY`, `DESCRIPTION`, `STATUS`, `PERCENT-COMPLETE`, and `PRIORITY`
- Expose parsed to-dos on `ICalendar.todos`
- Mark `VTODO` parsing complete in the README roadmap

## Example ICS
```ics
BEGIN:VTODO
UID:todo-test
DTSTAMP:20240728T120000Z
DTSTART:20240729T090000Z
DUE:20240730T170000Z
SUMMARY:Submit report
STATUS:IN-PROCESS
PERCENT-COMPLETE:50
END:VTODO
```

## What becomes available
```swift
let todo = calendar.todos.first
todo?.uid // "todo-test"
todo?.summary // "Submit report"
todo?.percentComplete // 50
```

## Validation
- `swift test`
- `swiftlint lint --quiet`