### PR TITLE
feat: parse vjournal components

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ iCalendarParser is currently not feature complete yet. While it requires an addi
   - [x] Parse `VEVENT`
   - [x] Parse `VTIMEZONE`
   - [ ] Parse `VTODO`
-  - [ ] Parse `VJOURNAL`
+  - [x] Parse `VJOURNAL`
   - [ ] Parse `VFREEBUSY`
   - [ ] Parse `VALARM`
 - [ ] `VEVENT` properties

--- a/Sources/iCalendarParser/Constant/Constant.swift
+++ b/Sources/iCalendarParser/Constant/Constant.swift
@@ -8,6 +8,7 @@ public enum Constant {
         public static let alarm = "VALARM"
         public static let daylight = "DAYLIGHT"
         public static let event = "VEVENT"
+        public static let journal = "VJOURNAL"
         public static let timeZone = "VTIMEZONE"
         public static let standard = "STANDARD"
     }

--- a/Sources/iCalendarParser/Models/ICComponentType.swift
+++ b/Sources/iCalendarParser/Models/ICComponentType.swift
@@ -4,6 +4,7 @@ enum ICComponentType {
 
     case alarm
     case event
+    case journal
     case timeZone
 
     var name: String {
@@ -12,6 +13,8 @@ enum ICComponentType {
             return Constant.Component.alarm
         case .event:
             return Constant.Component.event
+        case .journal:
+            return Constant.Component.journal
         case .timeZone:
             return Constant.Component.timeZone
         }

--- a/Sources/iCalendarParser/Models/ICJournal.swift
+++ b/Sources/iCalendarParser/Models/ICJournal.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// A grouping of component properties that describe a journal entry.
+///
+/// See more in [RFC 5545](
+/// https://www.rfc-editor.org/rfc/rfc5545#section-3.6.3)
+public struct ICJournal: ICComponentable, Equatable {
+
+    let type: ICComponentType = .journal
+
+    public var description: String?
+    public var dtStamp: Date?
+    public var dtStart: ICDateTime?
+    public var properties: [ICProperty]?
+    public var status: String?
+    public var summary: String?
+    public var uid: String
+
+    public init(
+        description: String? = nil,
+        dtStamp: Date? = nil,
+        dtStart: ICDateTime? = nil,
+        properties: [ICProperty]? = nil,
+        status: String? = nil,
+        summary: String? = nil,
+        uid: String = ""
+    ) {
+        self.description = description
+        self.dtStamp = dtStamp
+        self.dtStart = dtStart
+        self.properties = properties
+        self.status = status
+        self.summary = summary
+        self.uid = uid
+    }
+}

--- a/Sources/iCalendarParser/Models/ICalendar.swift
+++ b/Sources/iCalendarParser/Models/ICalendar.swift
@@ -7,7 +7,7 @@ import Foundation
 public struct ICalendar {
 
     var components: [ICComponentable] {
-        [events, timeZones]
+        [events, journals, timeZones]
             .compactMap { $0 as? [ICComponentable] }
             .flatMap { $0 }
     }
@@ -25,6 +25,9 @@ public struct ICalendar {
 
     /// All the event components in the object
     public var events: [ICEvent]
+
+    /// All the journal components in the object.
+    public var journals: [ICJournal]
 
     /// iCalendar object method associated with the calendar object.
     ///
@@ -74,6 +77,7 @@ public struct ICalendar {
     public init(
         calendarScale: String? = Constant.ICalSpec.defaultCalScale,
         events: [ICEvent] = [],
+        journals: [ICJournal] = [],
         method: String? = nil,
         productId: ICProductIdentifier,
         timeZones: [ICTimeZone] = [],
@@ -81,6 +85,7 @@ public struct ICalendar {
     ) {
         self.calendarScale = calendarScale
         self.events = events
+        self.journals = journals
         self.method = method
         self.productId = productId
         self.timeZones = timeZones
@@ -92,6 +97,7 @@ extension ICalendar: Equatable {
     public static func == (lhs: ICalendar, rhs: ICalendar) -> Bool {
         lhs.calendarScale == rhs.calendarScale
         && lhs.events == rhs.events
+        && lhs.journals == rhs.journals
         && lhs.method == rhs.method
         && lhs.productId == rhs.productId
         && lhs.timeZones == rhs.timeZones

--- a/Sources/iCalendarParser/Parser/ICParser.swift
+++ b/Sources/iCalendarParser/Parser/ICParser.swift
@@ -41,17 +41,24 @@ public struct ICParser {
             from: elements
         )
 
+        let journalComponents = getComponents(
+            type: .journal,
+            from: elements
+        )
+
         let timeZoneComponents = getComponents(
             type: .timeZone,
             from: elements
         )
 
         let events = buildEvents(from: eventComponents)
+        let journals = buildJournals(from: journalComponents)
         let timeZones = buildTimeZones(from: timeZoneComponents)
 
         return ICalendar(
             calendarScale: calendarScale,
             events: events,
+            journals: journals,
             method: method,
             productId: prodId,
             timeZones: timeZones
@@ -231,6 +238,22 @@ public struct ICParser {
                 nonStandardPropertyDetails: nonStandardPropertyDetails,
                 standard: standard,
                 timeZoneId: tzid
+            )
+        }
+    }
+
+    private func buildJournals(
+        from components: [ICComponent]
+    ) -> [ICJournal] {
+        components.map { component in
+            ICJournal(
+                description: component.buildProperty(of: Constant.Property.description),
+                dtStamp: component.buildProperty(of: Constant.Property.dtStamp)?.date,
+                dtStart: component.buildProperty(of: Constant.Property.dtStart),
+                properties: component.contentProperties,
+                status: component.buildProperty(of: Constant.Property.status),
+                summary: component.buildProperty(of: Constant.Property.summary),
+                uid: component.buildProperty(of: Constant.Property.uid) ?? ""
             )
         }
     }

--- a/Tests/iCalendarParserTests/JournalTests.swift
+++ b/Tests/iCalendarParserTests/JournalTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import iCalendarParser
+
+final class JournalTests: XCTestCase {
+    func testParserBuildsJournalComponent() throws {
+        let iCalString = """
+        BEGIN:VCALENDAR\r
+        VERSION:2.0\r
+        PRODID:-//Example Inc//Calendar//EN\r
+        BEGIN:VJOURNAL\r
+        UID:journal-test\r
+        DTSTAMP:20240728T120000Z\r
+        DTSTART;VALUE=DATE:20240729\r
+        SUMMARY:Daily note\r
+        DESCRIPTION:Retrospective notes\r
+        STATUS:FINAL\r
+        END:VJOURNAL\r
+        END:VCALENDAR
+        """
+
+        let calendar = try XCTUnwrap(ICParser().calendar(from: iCalString))
+        let journal = try XCTUnwrap(calendar.journals.first)
+
+        XCTAssertEqual(calendar.journals.count, 1)
+        XCTAssertEqual(journal.uid, "journal-test")
+        XCTAssertEqual(journal.summary, "Daily note")
+        XCTAssertEqual(journal.description, "Retrospective notes")
+        XCTAssertEqual(journal.status, "FINAL")
+        XCTAssertEqual(journal.dtStart?.type, .date)
+        XCTAssertNotNil(journal.properties?.first { $0.baseName == "SUMMARY" })
+    }
+}


### PR DESCRIPTION
## Summary
- Add an `ICJournal` model for parsed `VJOURNAL` components
- Parse common journal fields including `UID`, `DTSTAMP`, `DTSTART`, `SUMMARY`, `DESCRIPTION`, and `STATUS`
- Expose parsed journals on `ICalendar.journals`
- Mark `VJOURNAL` parsing complete in the README roadmap

## Example ICS
```ics
BEGIN:VJOURNAL
UID:journal-test
DTSTAMP:20240728T120000Z
DTSTART;VALUE=DATE:20240729
SUMMARY:Daily note
DESCRIPTION:Retrospective notes
STATUS:FINAL
END:VJOURNAL
```

## What becomes available
```swift
let journal = calendar.journals.first
journal?.uid // "journal-test"
journal?.summary // "Daily note"
journal?.dtStart?.type // .date
```

## Validation
- `swift test`
- `swiftlint lint --quiet`