### PR TITLE
feat: parse vfreebusy components

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ iCalendarParser is currently not feature complete yet. While it requires an addi
   - [x] Parse `VTIMEZONE`
   - [ ] Parse `VTODO`
   - [ ] Parse `VJOURNAL`
-  - [ ] Parse `VFREEBUSY`
+  - [x] Parse `VFREEBUSY`
   - [ ] Parse `VALARM`
 - [ ] `VEVENT` properties
   - [x] Add `COMMENT`, `CONTACT`, and `RESOURCES`

--- a/Sources/iCalendarParser/Constant/Constant.swift
+++ b/Sources/iCalendarParser/Constant/Constant.swift
@@ -8,6 +8,7 @@ public enum Constant {
         public static let alarm = "VALARM"
         public static let daylight = "DAYLIGHT"
         public static let event = "VEVENT"
+        public static let freeBusy = "VFREEBUSY"
         public static let timeZone = "VTIMEZONE"
         public static let standard = "STANDARD"
     }
@@ -66,6 +67,7 @@ extension Constant {
 
         static let attachment: String = "ATTACH"
         static let formatType: String = "FMTTYPE"
+        static let freeBusy: String = "FREEBUSY"
         static let categories: String = "CATEGORIES"
         static let comment: String = "COMMENT"
         static let contact: String = "CONTACT"

--- a/Sources/iCalendarParser/Models/ICComponent.swift
+++ b/Sources/iCalendarParser/Models/ICComponent.swift
@@ -152,6 +152,25 @@ struct ICComponent {
         return dateTimes.isEmpty ? nil : dateTimes
     }
 
+    /// Returns period values from all matching properties.
+    func buildPeriods(
+        of name: String
+    ) -> [ICPeriod]? {
+        guard let props = getProperties(name: name), !props.isEmpty else {
+            return nil
+        }
+
+        let periods = props.flatMap { prop in
+            prop.value
+                .components(separatedBy: ",")
+                .compactMap {
+                    PropertyBuilder.buildPeriod(from: ICProperty(prop.name, $0))
+                }
+        }
+
+        return periods.isEmpty ? nil : periods
+    }
+
     /// Returns request-status values from all matching properties.
     func buildRequestStatuses(
         of name: String

--- a/Sources/iCalendarParser/Models/ICComponentType.swift
+++ b/Sources/iCalendarParser/Models/ICComponentType.swift
@@ -4,6 +4,7 @@ enum ICComponentType {
 
     case alarm
     case event
+    case freeBusy
     case timeZone
 
     var name: String {
@@ -12,6 +13,8 @@ enum ICComponentType {
             return Constant.Component.alarm
         case .event:
             return Constant.Component.event
+        case .freeBusy:
+            return Constant.Component.freeBusy
         case .timeZone:
             return Constant.Component.timeZone
         }

--- a/Sources/iCalendarParser/Models/ICFreeBusy.swift
+++ b/Sources/iCalendarParser/Models/ICFreeBusy.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// A grouping of component properties that describe free/busy time.
+///
+/// See more in [RFC 5545](
+/// https://www.rfc-editor.org/rfc/rfc5545#section-3.6.4)
+public struct ICFreeBusy: ICComponentable, Equatable {
+
+    let type: ICComponentType = .freeBusy
+
+    public var dtEnd: ICDateTime?
+    public var dtStamp: Date?
+    public var dtStart: ICDateTime?
+    public var freeBusy: [ICPeriod]?
+    public var organizer: String?
+    public var properties: [ICProperty]?
+    public var uid: String
+    public var url: URL?
+
+    public init(
+        dtEnd: ICDateTime? = nil,
+        dtStamp: Date? = nil,
+        dtStart: ICDateTime? = nil,
+        freeBusy: [ICPeriod]? = nil,
+        organizer: String? = nil,
+        properties: [ICProperty]? = nil,
+        uid: String = "",
+        url: URL? = nil
+    ) {
+        self.dtEnd = dtEnd
+        self.dtStamp = dtStamp
+        self.dtStart = dtStart
+        self.freeBusy = freeBusy
+        self.organizer = organizer
+        self.properties = properties
+        self.uid = uid
+        self.url = url
+    }
+}

--- a/Sources/iCalendarParser/Models/ICalendar.swift
+++ b/Sources/iCalendarParser/Models/ICalendar.swift
@@ -7,7 +7,7 @@ import Foundation
 public struct ICalendar {
 
     var components: [ICComponentable] {
-        [events, timeZones]
+        [events, freeBusy, timeZones]
             .compactMap { $0 as? [ICComponentable] }
             .flatMap { $0 }
     }
@@ -25,6 +25,9 @@ public struct ICalendar {
 
     /// All the event components in the object
     public var events: [ICEvent]
+
+    /// All the free/busy components in the object.
+    public var freeBusy: [ICFreeBusy]
 
     /// iCalendar object method associated with the calendar object.
     ///
@@ -74,6 +77,7 @@ public struct ICalendar {
     public init(
         calendarScale: String? = Constant.ICalSpec.defaultCalScale,
         events: [ICEvent] = [],
+        freeBusy: [ICFreeBusy] = [],
         method: String? = nil,
         productId: ICProductIdentifier,
         timeZones: [ICTimeZone] = [],
@@ -81,6 +85,7 @@ public struct ICalendar {
     ) {
         self.calendarScale = calendarScale
         self.events = events
+        self.freeBusy = freeBusy
         self.method = method
         self.productId = productId
         self.timeZones = timeZones
@@ -92,6 +97,7 @@ extension ICalendar: Equatable {
     public static func == (lhs: ICalendar, rhs: ICalendar) -> Bool {
         lhs.calendarScale == rhs.calendarScale
         && lhs.events == rhs.events
+        && lhs.freeBusy == rhs.freeBusy
         && lhs.method == rhs.method
         && lhs.productId == rhs.productId
         && lhs.timeZones == rhs.timeZones

--- a/Sources/iCalendarParser/Parser/ICParser.swift
+++ b/Sources/iCalendarParser/Parser/ICParser.swift
@@ -41,17 +41,24 @@ public struct ICParser {
             from: elements
         )
 
+        let freeBusyComponents = getComponents(
+            type: .freeBusy,
+            from: elements
+        )
+
         let timeZoneComponents = getComponents(
             type: .timeZone,
             from: elements
         )
 
         let events = buildEvents(from: eventComponents)
+        let freeBusy = buildFreeBusy(from: freeBusyComponents)
         let timeZones = buildTimeZones(from: timeZoneComponents)
 
         return ICalendar(
             calendarScale: calendarScale,
             events: events,
+            freeBusy: freeBusy,
             method: method,
             productId: prodId,
             timeZones: timeZones
@@ -231,6 +238,23 @@ public struct ICParser {
                 nonStandardPropertyDetails: nonStandardPropertyDetails,
                 standard: standard,
                 timeZoneId: tzid
+            )
+        }
+    }
+
+    private func buildFreeBusy(
+        from components: [ICComponent]
+    ) -> [ICFreeBusy] {
+        components.map { component in
+            ICFreeBusy(
+                dtEnd: component.buildProperty(of: Constant.Property.dtEnd),
+                dtStamp: component.buildProperty(of: Constant.Property.dtStamp)?.date,
+                dtStart: component.buildProperty(of: Constant.Property.dtStart),
+                freeBusy: component.buildPeriods(of: Constant.Property.freeBusy),
+                organizer: component.buildProperty(of: Constant.Property.organizer),
+                properties: component.contentProperties,
+                uid: component.buildProperty(of: Constant.Property.uid) ?? "",
+                url: component.buildURI(of: Constant.Property.url)
             )
         }
     }

--- a/Tests/iCalendarParserTests/FreeBusyTests.swift
+++ b/Tests/iCalendarParserTests/FreeBusyTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import iCalendarParser
+
+final class FreeBusyTests: XCTestCase {
+    func testParserBuildsFreeBusyComponent() throws {
+        let iCalString = """
+        BEGIN:VCALENDAR\r
+        VERSION:2.0\r
+        PRODID:-//Example Inc//Calendar//EN\r
+        BEGIN:VFREEBUSY\r
+        UID:freebusy-test\r
+        DTSTAMP:20240728T120000Z\r
+        DTSTART:20240729T090000Z\r
+        DTEND:20240729T170000Z\r
+        ORGANIZER:mailto:organizer@example.com\r
+        FREEBUSY:20240729T100000Z/20240729T110000Z,\r
+         20240729T130000Z/PT30M\r
+        URL:https://example.com/freebusy/freebusy-test\r
+        END:VFREEBUSY\r
+        END:VCALENDAR
+        """
+
+        let calendar = try XCTUnwrap(ICParser().calendar(from: iCalString))
+        let freeBusy = try XCTUnwrap(calendar.freeBusy.first)
+
+        XCTAssertEqual(calendar.freeBusy.count, 1)
+        XCTAssertEqual(freeBusy.uid, "freebusy-test")
+        XCTAssertEqual(freeBusy.organizer, "mailto:organizer@example.com")
+        XCTAssertEqual(freeBusy.url?.absoluteString, "https://example.com/freebusy/freebusy-test")
+        XCTAssertEqual(freeBusy.freeBusy?.count, 2)
+        XCTAssertEqual(format(freeBusy.freeBusy?.first?.start), "20240729T100000Z")
+        XCTAssertEqual(format(freeBusy.freeBusy?.first?.end), "20240729T110000Z")
+        XCTAssertEqual(freeBusy.freeBusy?[1].duration?.minutes, 30)
+    }
+
+    private func format(
+        _ dateTime: ICDateTime?
+    ) -> String? {
+        dateTime.map {
+            $0.type.dateFormatter(tzId: $0.tzId).string(from: $0.date)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add an `ICFreeBusy` model for parsed `VFREEBUSY` components
- Parse common free/busy fields including `UID`, `DTSTAMP`, `DTSTART`, `DTEND`, `ORGANIZER`, `FREEBUSY`, and `URL`
- Parse `FREEBUSY` values into `ICPeriod` entries
- Expose parsed free/busy components on `ICalendar.freeBusy`
- Mark `VFREEBUSY` parsing complete in the README roadmap

## Example ICS
```ics
BEGIN:VFREEBUSY
UID:freebusy-test
DTSTAMP:20240728T120000Z
DTSTART:20240729T090000Z
DTEND:20240729T170000Z
ORGANIZER:mailto:organizer@example.com
FREEBUSY:20240729T100000Z/20240729T110000Z,20240729T130000Z/PT30M
END:VFREEBUSY
```

## What becomes available
```swift
let freeBusy = calendar.freeBusy.first
freeBusy?.uid // "freebusy-test"
freeBusy?.freeBusy?.first?.start
freeBusy?.freeBusy?[1].duration?.minutes // 30
```

## Validation
- `swift test`
- `swiftlint lint --quiet`